### PR TITLE
Logging settings

### DIFF
--- a/rdrf/explorer/utils.py
+++ b/rdrf/explorer/utils.py
@@ -20,7 +20,7 @@ from models import Query
 from forms import QueryForm
 
 import logging
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class MissingDataError(Exception):

--- a/rdrf/explorer/views.py
+++ b/rdrf/explorer/views.py
@@ -31,7 +31,7 @@ from itertools import product
 from rdrf.utils import models_from_mongo_key, is_delimited_key, BadKeyError, cached
 from rdrf.utils import mongo_key_from_models
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 def encode_row(row):

--- a/rdrf/rdrf/actions.py
+++ b/rdrf/rdrf/actions.py
@@ -1,6 +1,6 @@
 from rdrf import rpc_commands
 import logging
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class ActionExecutor(object):

--- a/rdrf/rdrf/adjudication_actions.py
+++ b/rdrf/rdrf/adjudication_actions.py
@@ -1,7 +1,7 @@
 from rdrf.notifications import Notifier
 import logging
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class AdjudicationAction(object):

--- a/rdrf/rdrf/admin.py
+++ b/rdrf/rdrf/admin.py
@@ -37,7 +37,7 @@ from admin_forms import RegistryFormAdminForm
 from admin_forms import DemographicFieldsAdminForm
 from functools import reduce
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class SectionAdmin(admin.ModelAdmin):

--- a/rdrf/rdrf/api_views.py
+++ b/rdrf/rdrf/api_views.py
@@ -19,7 +19,7 @@ from serializers import PatientSerializer, RegistrySerializer, WorkingGroupSeria
 
 
 import logging
-logger = logging.getLogger('registry_log')
+logger = logging.getLogger(__name__)
 
 
 class BadRequestError(APIException):

--- a/rdrf/rdrf/calculated_fields.py
+++ b/rdrf/rdrf/calculated_fields.py
@@ -2,7 +2,7 @@ import logging
 from django.conf import settings
 from django.core.urlresolvers import reverse
 
-logger = logging.getLogger('registry_log')
+logger = logging.getLogger(__name__)
 
 
 class CalculatedFieldParseError(Exception):

--- a/rdrf/rdrf/consent_forms.py
+++ b/rdrf/rdrf/consent_forms.py
@@ -7,7 +7,7 @@ from django.utils.datastructures import SortedDict
 
 import logging
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class BaseConsentForm(forms.BaseForm):

--- a/rdrf/rdrf/contexts_api.py
+++ b/rdrf/rdrf/contexts_api.py
@@ -4,7 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 
 import logging
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class RDRFContextError(Exception):

--- a/rdrf/rdrf/datasources.py
+++ b/rdrf/rdrf/datasources.py
@@ -1,5 +1,5 @@
 import logging
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class DataSource(object):

--- a/rdrf/rdrf/dynamic_data.py
+++ b/rdrf/rdrf/dynamic_data.py
@@ -13,7 +13,7 @@ from copy import deepcopy
 
 
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class FileStore(object):

--- a/rdrf/rdrf/dynamic_forms.py
+++ b/rdrf/rdrf/dynamic_forms.py
@@ -5,7 +5,7 @@ from django.conf import settings
 import logging
 from rdrf.models import CdePolicy
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 def create_form_class(owner_class_name):

--- a/rdrf/rdrf/email_notification.py
+++ b/rdrf/rdrf/email_notification.py
@@ -6,7 +6,7 @@ from django.template import Context, Template
 import json
 import logging
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class RdrfEmailException(Exception):

--- a/rdrf/rdrf/email_notification_view.py
+++ b/rdrf/rdrf/email_notification_view.py
@@ -11,7 +11,7 @@ from models import EmailNotificationHistory
 
 from email_notification import RdrfEmail
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class ResendEmail(View):

--- a/rdrf/rdrf/exporter.py
+++ b/rdrf/rdrf/exporter.py
@@ -8,7 +8,7 @@ import datetime
 from rdrf.models import AdjudicationDefinition, DemographicFields, RegistryForm
 from explorer.models import Query
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class ExportException(Exception):

--- a/rdrf/rdrf/family_linkage.py
+++ b/rdrf/rdrf/family_linkage.py
@@ -15,7 +15,7 @@ from django.contrib import messages
 
 import logging
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 def fml_log(msg):
     logger.info("***FAMILY LINKAGE: %s" % msg)

--- a/rdrf/rdrf/field_lookup.py
+++ b/rdrf/rdrf/field_lookup.py
@@ -19,7 +19,7 @@ from django.utils.translation import ugettext_lazy as _
 
 mark_safe_lazy = lazy(mark_safe, six.text_type)
 
-logger = logging.getLogger('registry_log')
+logger = logging.getLogger(__name__)
 
 
 class FieldContext:

--- a/rdrf/rdrf/file_upload.py
+++ b/rdrf/rdrf/file_upload.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class FileUpload(object):

--- a/rdrf/rdrf/filestorage.py
+++ b/rdrf/rdrf/filestorage.py
@@ -1,7 +1,7 @@
 # Attempt to clean up the interaction with GridFS
 import logging
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class GridFSApi(object):

--- a/rdrf/rdrf/form_progress.py
+++ b/rdrf/rdrf/form_progress.py
@@ -10,7 +10,7 @@ import math
 import logging
 import datetime
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class ProgressType(object):

--- a/rdrf/rdrf/form_view.py
+++ b/rdrf/rdrf/form_view.py
@@ -56,7 +56,7 @@ from rdrf.contexts_api import RDRFContextManager, RDRFContextError
 
 from rdrf.form_progress import FormProgress
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 login_required_method = method_decorator(login_required)
 
 

--- a/rdrf/rdrf/generalised_field_expressions.py
+++ b/rdrf/rdrf/generalised_field_expressions.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 
 import logging
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class FieldExpressionError(Exception):

--- a/rdrf/rdrf/genetic_validation.py
+++ b/rdrf/rdrf/genetic_validation.py
@@ -3,7 +3,7 @@ from registry.humangenome.exon import ExonVariation
 from registry.humangenome.protein import ProteinVariation
 from registry.humangenome.sequence import SequenceVariation
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class GeneticType:

--- a/rdrf/rdrf/hooking.py
+++ b/rdrf/rdrf/hooking.py
@@ -6,7 +6,7 @@ import logging
 from rdrf.models import Registry
 
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 def hook(hook_name):

--- a/rdrf/rdrf/hooks/fh_hooks.py
+++ b/rdrf/rdrf/hooks/fh_hooks.py
@@ -2,7 +2,7 @@ from rdrf.hooking import hook
 
 from logging import getLogger
 
-logger = getLogger("registry_log")
+logger = getLogger(__name__)
 
 
 @hook("patient_created_from_relative")

--- a/rdrf/rdrf/import_registry_view.py
+++ b/rdrf/rdrf/import_registry_view.py
@@ -10,7 +10,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 import logging
 from django.contrib.auth import get_user_model
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class ImportRegistryView(View):

--- a/rdrf/rdrf/importer.py
+++ b/rdrf/rdrf/importer.py
@@ -24,7 +24,7 @@ from utils import create_permission
 import yaml
 import json
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 # We want all YAML strings to be converted to unicode objects

--- a/rdrf/rdrf/lookup_views.py
+++ b/rdrf/rdrf/lookup_views.py
@@ -15,7 +15,7 @@ from rdrf.models import RDRFContext, RDRFContextError
 import pycountry
 
 import logging
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 # TODO replace these views as well with Django REST framework views

--- a/rdrf/rdrf/models.py
+++ b/rdrf/rdrf/models.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class InvalidStructureError(Exception):

--- a/rdrf/rdrf/notifications.py
+++ b/rdrf/rdrf/notifications.py
@@ -2,7 +2,7 @@ import logging
 from rdrf.utils import get_user
 from django.conf import settings
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class NotificationError(Exception):

--- a/rdrf/rdrf/patient_decorators.py
+++ b/rdrf/rdrf/patient_decorators.py
@@ -7,7 +7,7 @@ import logging
 
 from models import Registry
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 def patient_has_access(function):

--- a/rdrf/rdrf/patient_view.py
+++ b/rdrf/rdrf/patient_view.py
@@ -34,7 +34,7 @@ from rdrf.contexts_api import RDRFContextManager, RDRFContextError
 
 import logging
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 def calculate_age(born):

--- a/rdrf/rdrf/permission_matrix.py
+++ b/rdrf/rdrf/permission_matrix.py
@@ -11,7 +11,7 @@ from rdrf.utils import get_form_links
 from django.utils.translation import ugettext_lazy as _
 import logging
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class MatrixRow(object):

--- a/rdrf/rdrf/questionnaires.py
+++ b/rdrf/rdrf/questionnaires.py
@@ -15,7 +15,7 @@ from datetime import datetime, date, time
 import pycountry
 
 import logging
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 CONSENTS_SECTION = "custom_consent_data"
 

--- a/rdrf/rdrf/rdrf_contexts.py
+++ b/rdrf/rdrf/rdrf_contexts.py
@@ -7,7 +7,7 @@ from rdrf.models import Registry
 from registry.patients.models import Patient
 
 import logging
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class RDRFContextCommandHandler(object):

--- a/rdrf/rdrf/registry_specific_fields.py
+++ b/rdrf/rdrf/registry_specific_fields.py
@@ -6,7 +6,7 @@ from rdrf.filestorage import GridFSApi
 
 
 import logging
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class FileCommand:

--- a/rdrf/rdrf/registry_view.py
+++ b/rdrf/rdrf/registry_view.py
@@ -7,7 +7,7 @@ import logging
 
 from models import Registry
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class RegistryView(View):

--- a/rdrf/rdrf/report_view.py
+++ b/rdrf/rdrf/report_view.py
@@ -13,7 +13,7 @@ from rdrf.reporting_table import ReportTable
 import json
 from datetime import datetime
 import logging
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class LoginRequiredMixin(object):

--- a/rdrf/rdrf/reporting_table.py
+++ b/rdrf/rdrf/reporting_table.py
@@ -6,7 +6,7 @@ from explorer.utils import DatabaseUtils
 from rdrf.utils import timed
 
 import logging
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 from django.conf import settings
 

--- a/rdrf/rdrf/rpc_commands.py
+++ b/rdrf/rdrf/rpc_commands.py
@@ -1,5 +1,5 @@
 import logging
-logger = logging.getLogger('registry_log')
+logger = logging.getLogger(__name__)
 
 
 def rpc_visibility(request, element):

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -73,7 +73,7 @@ DATABASES = {
     # }
 }
 
-# Reporing Database ( defaults to main db if not specified 
+# Reporing Database ( defaults to main db if not specified
 DATABASES["reporting"] = {}
 
 DATABASES["reporting"]['ENGINE']   = env.get_db_engine("reporting_dbtype", "pgsql")
@@ -188,7 +188,7 @@ EMAIL_SUBJECT_PREFIX = env.get("email_subject_prefix", "DEV {0}".format(SCRIPT_N
 SERVER_EMAIL = env.get("server_email", "noreply@ccg_rdrf")
 
 # Django Notifications
-DEFAULT_FROM_EMAIL = env.get("default_from_email", "No Reply <no-reply@mg.ccgapps.com.au>") 
+DEFAULT_FROM_EMAIL = env.get("default_from_email", "No Reply <no-reply@mg.ccgapps.com.au>")
 # Mail Gun
 EMAIL_BACKEND = 'django_mailgun.MailgunBackend'
 MAILGUN_ACCESS_KEY = env.get('DJANGO_MAILGUN_API_KEY', "")
@@ -286,95 +286,90 @@ else:
 # # LOGGING
 # #
 LOG_DIRECTORY = env.get('log_directory', os.path.join(WEBAPP_ROOT, "log"))
-try:
-    if not os.path.exists(LOG_DIRECTORY):
-        os.mkdir(LOG_DIRECTORY)
-except:
-    pass
-os.path.exists(LOG_DIRECTORY), "No log directory, please create one: %s" % LOG_DIRECTORY
 
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': True,
+    'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
-            'format': 'Registry [%(levelname)s:%(asctime)s:%(filename)s:%(lineno)s:%(funcName)s] %(message)s'
+            'format': '[%(levelname)s:%(asctime)s:%(filename)s:%(lineno)s:%(funcName)s] %(message)s'
         },
         'db': {
-            'format': 'Registry [%(duration)s:%(sql)s:%(params)s] %(message)s'
+            'format': '[%(duration)s:%(sql)s:%(params)s] %(message)s'
         },
         'simple': {
-            'format': 'Registry %(levelname)s %(message)s'
+            'format': '%(levelname)s %(message)s'
         },
     },
     'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        },
+        'require_debug_true': {
+            '()': 'django.utils.log.RequireDebugTrue',
+        },
     },
     'handlers': {
-        'null': {
-            'level': 'DEBUG',
-            'class': 'django.utils.log.NullHandler',
-        },
         'console': {
             'level': 'DEBUG',
+            'filters': ['require_debug_true'],
             'class': 'logging.StreamHandler',
             'formatter': 'verbose'
         },
-        'errorfile': {
-            'level': 'ERROR',
-            'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filename': os.path.join(LOG_DIRECTORY, 'error.log'),
-            'when': 'midnight',
-            'formatter': 'verbose'
+        'shell': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple'
         },
-        'registryfile': {
-            'class': 'logging.handlers.TimedRotatingFileHandler',
+        'file': {
+            'level': 'INFO',
+            'class': 'ccg_django_utils.loghandlers.ParentPathFileHandler',
             'filename': os.path.join(LOG_DIRECTORY, 'registry.log'),
-            'when': 'midnight',
-            'formatter': 'verbose'
-        },
-        'db_logfile': {
-            'level': 'DEBUG',
-            'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filename': os.path.join(LOG_DIRECTORY, 'registry_db.log'),
-            'when': 'midnight',
-            'formatter': 'db'
-        },
-         'access_logfile': {
-            'level': 'DEBUG',
-            'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filename': os.path.join(LOG_DIRECTORY, 'access.log'),
             'when': 'midnight',
             'formatter': 'verbose'
         },
         'mail_admins': {
             'level': 'ERROR',
-            'filters': [],
+            'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler',
-            'formatter': 'verbose',
             'include_html': True
-        }
-    },
-    'root': {
-        'handlers': ['console', 'errorfile', 'mail_admins'],
-        'level': 'ERROR',
+        },
+        'null': {
+            'class': 'django.utils.log.NullHandler',
+        },
     },
     'loggers': {
         'django': {
-            'handlers': ['null'],
-            'propagate': False,
-            'level': 'INFO',
+            'handlers': ['console', 'file'],
+        },
+        'django.request': {
+            'handlers': ['mail_admins'],
+            'level': 'ERROR',
+            'propagate': True,
+        },
+        'django.security': {
+            'handlers': ['mail_admins'],
+            'level': 'ERROR',
+            'propagate': True,
+        },
+        'django.db.backends': {
+            'handlers': ['mail_admins'],
+            'level': 'CRITICAL',
+            'propagate': True,
         },
         'registry_log': {
-            'handlers': ['registryfile', 'console'],
+            'handlers': ['console', 'file'],
             'level': 'DEBUG',
             'propagate': False,
         },
-        # The following logger used by django useraudit
-        'django.security': {
-            'handlers': ['access_logfile', 'console'],
+        'rdrf.rdrf.management.commands': {
+            'handlers': ['shell'],
             'level': 'DEBUG',
             'propagate': False,
-        }
+        },
+        'py.warnings': {
+            'handlers': ['console'],
+        },
     }
 }
 

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -357,7 +357,7 @@ LOGGING = {
             'level': 'CRITICAL',
             'propagate': True,
         },
-        'registry_log': {
+        'rdrf': {
             'handlers': ['console', 'file'],
             'level': 'DEBUG',
             'propagate': False,

--- a/rdrf/rdrf/spreadsheet_report.py
+++ b/rdrf/rdrf/spreadsheet_report.py
@@ -12,7 +12,7 @@ from rdrf.models import Registry, RegistryForm, Section, CommonDataElement
 from rdrf.mongo_client import construct_mongo_client
 from rdrf.generalised_field_expressions import GeneralisedFieldExpressionParser
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 class Cache(object):
     LIMIT_SNAPSHOT = 2000

--- a/rdrf/rdrf/utils.py
+++ b/rdrf/rdrf/utils.py
@@ -13,7 +13,7 @@ import functools
 import os.path
 import subprocess
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class BadKeyError(Exception):
@@ -337,7 +337,7 @@ def get_error_messages(forms):
 def timed(func):
     from logging import getLogger
     from datetime import datetime
-    logger = logging.getLogger("registry_log")
+    logger = logging.getLogger(__name__)
     def wrapper(*args, **kwargs):
         a = datetime.now()
         result = func(*args, **kwargs)

--- a/rdrf/rdrf/validation.py
+++ b/rdrf/rdrf/validation.py
@@ -3,7 +3,7 @@ import re
 
 from django.core.exceptions import ValidationError
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class ValidationType:

--- a/rdrf/rdrf/widgets.py
+++ b/rdrf/rdrf/widgets.py
@@ -8,7 +8,7 @@ import logging
 from models import CommonDataElement
 import pycountry
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class BadCustomFieldWidget(Textarea):

--- a/rdrf/registry/common/report_utils.py
+++ b/rdrf/registry/common/report_utils.py
@@ -1,6 +1,6 @@
 import logging
 from functools import reduce
-logger = logging.getLogger('registry_log')
+logger = logging.getLogger(__name__)
 
 
 class SimpleReport(object):

--- a/rdrf/registry/groups/admin.py
+++ b/rdrf/registry/groups/admin.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ValidationError
 
 import logging
 
-logger = logging.getLogger('registry_log')
+logger = logging.getLogger(__name__)
 
 
 class WorkingGroupAdmin(admin.ModelAdmin):

--- a/rdrf/registry/groups/models.py
+++ b/rdrf/registry/groups/models.py
@@ -20,7 +20,7 @@ from rdrf.models import Registry
 
 import logging
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class WorkingGroup(models.Model):

--- a/rdrf/registry/patients/admin.py
+++ b/rdrf/registry/patients/admin.py
@@ -20,7 +20,7 @@ import logging
 from rdrf.utils import has_feature
 from registry.patients.models import ConsentValue
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class DoctorAdmin(admin.ModelAdmin):

--- a/rdrf/registry/patients/admin_forms.py
+++ b/rdrf/registry/patients/admin_forms.py
@@ -7,7 +7,7 @@ from rdrf.widgets import CountryWidget, StateWidget, DateWidget
 from rdrf.dynamic_data import DynamicDataWrapper
 import pycountry
 import logging
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 from registry.patients.patient_widgets import PatientRelativeLinkWidget
 from django.core.exceptions import ValidationError
 from django.forms.util import ErrorList, ErrorDict

--- a/rdrf/registry/patients/models.py
+++ b/rdrf/registry/patients/models.py
@@ -25,7 +25,7 @@ from django.db.models.signals import m2m_changed, post_delete
 
 
 import logging
-logger = logging.getLogger('registry_log')
+logger = logging.getLogger(__name__)
 
 file_system = FileSystemStorage(location=settings.MEDIA_ROOT, base_url=settings.MEDIA_URL)
 

--- a/rdrf/registry/patients/patient_widgets.py
+++ b/rdrf/registry/patients/patient_widgets.py
@@ -4,7 +4,7 @@ import hashlib
 import random
 from django.core.urlresolvers import reverse
 
-logger = logging.getLogger("registry_log")
+logger = logging.getLogger(__name__)
 
 
 class PatientRelativeLinkWidget(widgets.Widget):


### PR DESCRIPTION
1. Increase log level filter to INFO when logging to registry.log.

2. Log DEBUG level messages to the console, but only if settings.DEBUG is True. Production installs shouldn't have settings.DEBUG on.

3. Error log messages now go into the main registry.log instead of a separate error.log.

4. registry_db.log is removed. Database logging is only interesting if it's an error, and that should be e-mailed. Other database log messages are propagated into the main log.

5. access.log is removed. This file would only contain messages about accounts expiring, and no other interesting things. Django security errors are e-mailed, and propagated to the main log.

6. Use the log handler from ccg_django_utils which automatically creates the log directory and parent directories.

7. Added logging of Python warnings.

8. Added log handler which can be used by management commands.

9. Loggers are now called `rdrf.*`, i.e. the module name is used as the logger name.
