### PR TITLE
RDR-1350 pymongo 2.9.3

### DIFF
--- a/rdrf/runtime-requirements.txt
+++ b/rdrf/runtime-requirements.txt
@@ -1,5 +1,5 @@
 Django==1.8.12
-pymongo==2.8.1
+pymongo==2.9.3
 pyyaml
 django-extensions>=0.7.1
 django-templatetag-sugar==1.0


### PR DESCRIPTION
Upgrade path for mongo.

https://api.mongodb.com/python/2.9/changelog.html
https://api.mongodb.com/python/2.9/migrate-to-pymongo3.html

Checked the migration path, none of the deprecated api in the code base.