### PR TITLE
Rdr 1357 deprecate django secure

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -84,6 +84,12 @@ function selenium_defaults {
 }
 
 
+function _django_check_deploy {
+    echo "running migrate"
+    django-admin.py check --deploy --settings=${DJANGO_SETTINGS_MODULE} 2>&1 | tee /data/uwsgi-check.log
+}
+
+
 function _django_migrate {
     echo "running migrate"
     django-admin.py migrate --noinput --settings=${DJANGO_SETTINGS_MODULE} 2>&1 | tee /data/uwsgi-migrate.log
@@ -147,6 +153,7 @@ if [ "$1" = 'uwsgi' ]; then
 
     _django_collectstatic
     _django_migrate
+    _django_check_deploy
 
     exec uwsgi --die-on-term --ini ${UWSGI_OPTS}
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -85,7 +85,7 @@ function selenium_defaults {
 
 
 function _django_check_deploy {
-    echo "running migrate"
+    echo "running check --deploy"
     django-admin.py check --deploy --settings=${DJANGO_SETTINGS_MODULE} 2>&1 | tee /data/uwsgi-check.log
 }
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -168,6 +168,7 @@ if [ "$1" = 'uwsgi_fixtures' ]; then
     _django_collectstatic
     _django_migrate
     _django_dev_fixtures
+    _django_check_deploy
 
     exec uwsgi --die-on-term --ini ${UWSGI_OPTS}
 fi

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -27,6 +27,7 @@ SECURE_BROWSER_XSS_FILTER = env.get("secure_browser_xss_filter", PRODUCTION)
 SECURE_HSTS_SECONDS = env.get("secure_hsts_seconds", 10)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.get("secure_hsts_include_subdomains", PRODUCTION)
 SECURE_REDIRECT_EXEMPT = env.getlist("secure_redirect_exempt", [])
+X_FRAME_OPTIONS = env.get("x_frame_options", 'DENY')
 
 DEBUG = env.get("debug", not PRODUCTION)
 SITE_ID = env.get("site_id", 1)

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -127,7 +127,6 @@ MESSAGE_TAGS = {
 
 MIDDLEWARE_CLASSES = (
     'useraudit.middleware.RequestToThreadLocalMiddleware',
-    'django.middleware.security.SecurityMiddleware',
     'django.middleware.common.CommonMiddleware',
     'iprestrict.middleware.IPRestrictMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -135,6 +134,8 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
 )
 
 

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -237,6 +237,7 @@ CSRF_COOKIE_NAME = env.get("csrf_cookie_name", "csrf_{0}".format(SESSION_COOKIE_
 CSRF_COOKIE_DOMAIN = env.get("csrf_cookie_domain", "") or SESSION_COOKIE_DOMAIN
 CSRF_COOKIE_PATH = env.get("csrf_cookie_path", SESSION_COOKIE_PATH)
 CSRF_COOKIE_SECURE = env.get("csrf_cookie_secure", PRODUCTION)
+CSRF_COOKIE_HTTPONLY = env.get("csrf_cookie_httponly", True)
 
 # Testing settings
 INSTALLED_APPS.extend(['django_nose'])

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -24,8 +24,6 @@ SECURE_SSL_REDIRECT = env.get("secure_ssl_redirect", PRODUCTION)
 SECURE_SSL_HOST = env.get("secure_ssl_host", False)
 SECURE_CONTENT_TYPE_NOSNIFF = env.get("secure_content_type_nosniff", PRODUCTION)
 SECURE_BROWSER_XSS_FILTER = env.get("secure_browser_xss_filter", PRODUCTION)
-SECURE_HSTS_SECONDS = env.get("secure_hsts_seconds", 10)
-SECURE_HSTS_INCLUDE_SUBDOMAINS = env.get("secure_hsts_include_subdomains", PRODUCTION)
 SECURE_REDIRECT_EXEMPT = env.getlist("secure_redirect_exempt", [])
 X_FRAME_OPTIONS = env.get("x_frame_options", 'DENY')
 

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -19,13 +19,14 @@ WEBAPP_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # General site config
 PRODUCTION = env.get("production", False)
 
-# django-secure
+# https://docs.djangoproject.com/en/1.8/ref/middleware/#django.middleware.security.SecurityMiddleware
 SECURE_SSL_REDIRECT = env.get("secure_ssl_redirect", PRODUCTION)
-SECURE_FRAME_DENY = env.get("secure_frame_deny", PRODUCTION)
+SECURE_SSL_HOST = env.get("secure_ssl_host", False)
 SECURE_CONTENT_TYPE_NOSNIFF = env.get("secure_content_type_nosniff", PRODUCTION)
 SECURE_BROWSER_XSS_FILTER = env.get("secure_browser_xss_filter", PRODUCTION)
 SECURE_HSTS_SECONDS = env.get("secure_hsts_seconds", 10)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.get("secure_hsts_include_subdomains", PRODUCTION)
+SECURE_REDIRECT_EXEMPT = env.getlist("secure_redirect_exempt", [])
 
 DEBUG = env.get("debug", not PRODUCTION)
 SITE_ID = env.get("site_id", 1)
@@ -126,7 +127,7 @@ MESSAGE_TAGS = {
 
 MIDDLEWARE_CLASSES = (
     'useraudit.middleware.RequestToThreadLocalMiddleware',
-    'djangosecure.middleware.SecurityMiddleware',
+    'django.middleware.security.SecurityMiddleware',
     'django.middleware.common.CommonMiddleware',
     'iprestrict.middleware.IPRestrictMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -155,7 +156,6 @@ INSTALLED_APPS = [
     'ajax_select',
     'registration',
     'explorer',
-    'djangosecure',
     'useraudit',
     'templatetag_handlebars',
     'iprestrict',

--- a/rdrf/runtime-requirements.txt
+++ b/rdrf/runtime-requirements.txt
@@ -24,7 +24,6 @@ six==1.10.0
 python-gettext
 django-registration-redux==1.3
 psycopg2==2.6.1
-django-secure==1.0.1
 djangorestframework==3.3.3
 openpyxl
 SQLAlchemy


### PR DESCRIPTION
django-secure was deprecated in Django 1.8 and the functionality is now core Django.