### PR TITLE
enable lazy-apps uwsgi option

### DIFF
--- a/uwsgi/docker.ini
+++ b/uwsgi/docker.ini
@@ -5,4 +5,5 @@
 emperor      = /app/uwsgi/vassals
 touch-reload = /app/uwsgi/docker.ini
 vacuum       = True
+lazy-apps    = True
 env          = DJANGO_SETTINGS_MODULE=rdrf.settings

--- a/uwsgi/docker.ini
+++ b/uwsgi/docker.ini
@@ -5,5 +5,3 @@
 emperor      = /app/uwsgi/vassals
 touch-reload = /app/uwsgi/docker.ini
 vacuum       = True
-lazy-apps    = True
-env          = DJANGO_SETTINGS_MODULE=rdrf.settings

--- a/uwsgi/vassals/socket-9100.ini
+++ b/uwsgi/vassals/socket-9100.ini
@@ -22,3 +22,4 @@ processes    = 4
 threads      = 2
 master       = True
 vacuum       = True
+lazy-apps    = True


### PR DESCRIPTION
For an explanation of what lazy-apps does, see:
https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html#preforking-vs-lazy-apps-vs-lazy

By default, uwsgi loads the state of the app, including all libraries,
and then forks. This causes problems for some libraries, such as
SQLAlchemy:
https://stackoverflow.com/questions/22752521/uwsgi-flask-sqlalchemy-and-postgres-ssl-error-decryption-failed-or-bad-reco

To play it safe, we should enable lazy-apps.