### PR TITLE
Patients listing: contexts and modules dropdown #273

### DIFF
--- a/rdrf/rdrf/patients_listing.py
+++ b/rdrf/rdrf/patients_listing.py
@@ -474,6 +474,8 @@ class ColumnContextMenu(Column):
             self.free_forms = filter(user.can_view, registry.free_forms)
 
     def cell(self, patient, supports_contexts=False, form_progress=None, context_manager=None):
+        if supports_contexts:
+            return "N/A"
         return "".join(self._get_forms_buttons(patient))
 
     def _get_forms_buttons(self, patient, form_progress=None, context_manager=None):


### PR DESCRIPTION
Is this logic right?

```
registry supports contexts ⇒ disable modules dropdown in patients listing
```
