### PR TITLE
models: realign RegistryForm.position

### DIFF
--- a/rdrf/rdrf/migrations/0037_registryform_position.py
+++ b/rdrf/rdrf/migrations/0037_registryform_position.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+def make_positive(apps, schema_editor):
+    RegistryForm = apps.get_model("rdrf", "RegistryForm")
+    RegistryForm.objects.filter(position__lt=0).update(position=0)
+
+def do_nothing(apps, schema_editor):
+    pass
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rdrf', '0036_auto_20161026_1853'),
+    ]
+
+    operations = [
+        migrations.RunPython(make_positive, do_nothing),
+        migrations.AlterField(
+            model_name='registryform',
+            name='position',
+            field=models.PositiveIntegerField(default=0),
+        ),
+    ]

--- a/rdrf/rdrf/models.py
+++ b/rdrf/rdrf/models.py
@@ -849,7 +849,7 @@ class RegistryForm(models.Model):
         default=False,
         help_text="If the form is a questionnaire, is it accessible only by logged in users?",
         verbose_name="Questionnaire Login Required")
-    position = models.IntegerField(default=-1)
+    position = models.PositiveIntegerField(default=0)
     questionnaire_questions = models.TextField(
         blank=True, help_text="Comma-separated list of sectioncode.cdecodes for questionnnaire")
     complete_form_cdes = models.ManyToManyField(CommonDataElement, blank=True)


### PR DESCRIPTION
Between v0.5.2 and v0.5.3, django-positions changed its field type from PositiveIntegerField to IntegerField, but didn't provide a migration. Result is that the PostgreSQL constraint still exists, even after django-positions is no longer used.

This model change should bring the django field back into line with the table column.

If Django complains about a constraint already existing, then the migration will need to be forced.

Fixes muccg/angelman#162