### PR TITLE
File link display+ tests 

### DIFF
--- a/rdrf/rdrf/dynamic_data.py
+++ b/rdrf/rdrf/dynamic_data.py
@@ -598,7 +598,7 @@ class DynamicDataWrapper(object):
         elif is_uploaded_file(value):
             # A file was uploaded.
             # Store file and convert value into a file wrapper
-            to_delete = current_value
+            to_delete = False
             value = filestorage.store_file_by_key(registry_code, None, key, value)
         else:
             to_delete = None

--- a/rdrf/rdrf/dynamic_data.py
+++ b/rdrf/rdrf/dynamic_data.py
@@ -586,7 +586,8 @@ class DynamicDataWrapper(object):
             # Django uses a "clear" checkbox value of False to indicate file should be removed
             # we need to delete the file but not here
             logger.debug("User cleared %s - file will be deleted" % key)
-            to_delete = current_value
+            to_delete = True
+            file_ref = current_value
             value = None
         elif value is None:
             # No file upload means keep the current value
@@ -603,7 +604,7 @@ class DynamicDataWrapper(object):
             to_delete = None
 
         if to_delete:
-            filestorage.delete_file_wrapper(to_delete)
+            filestorage.delete_file_wrapper(file_ref)
 
         return value
 

--- a/rdrf/rdrf/dynamic_data.py
+++ b/rdrf/rdrf/dynamic_data.py
@@ -5,7 +5,7 @@ import logging
 from django.core.files.uploadedfile import InMemoryUploadedFile
 
 from . import filestorage
-from .file_upload import FileUpload, wrap_gridfs_data_for_form
+from .file_upload import FileUpload, wrap_fs_data_for_form
 from .models import Registry, Modjgo
 from .utils import get_code, models_from_mongo_key, is_delimited_key, mongo_key, is_multisection
 from .utils import is_file_cde, is_multiple_file_cde, is_uploaded_file
@@ -100,7 +100,7 @@ def update_multisection_file_cdes(registry_code,
                                   form_model, existing_nested_data, index_map):
 
     logger.debug("****************** START UPDATE MULTISECTION FILE CDES ****************************")
-    logger.debug("updating any gridfs files in multisection %s" % multisection_code)
+    logger.debug("updating any fs files in multisection %s" % multisection_code)
 
     updates = []
 
@@ -254,8 +254,8 @@ class FormDataParser(object):
                 logger.debug("existing cde dict = %s" % cde_dict)
                 if self._is_file(value):
                     logger.debug("nested data - file value = %s" % value)
-                    # should check here is we're updating a file in gridfs - the old file needs to be deleted
-                    value = self._get_gridfs_value(value)
+                    # should check here is we're updating a file in fs - the old file needs to be deleted
+                    value = self._get_fs_value(value)
                     logger.debug("value is now: %s" % value)
 
                 cde_dict["value"] = value
@@ -270,7 +270,7 @@ class FormDataParser(object):
     def _is_file(self, value):
         return isinstance(value, InMemoryUploadedFile)
 
-    def _get_gridfs_value(self, inmemory_uploaded_file):
+    def _get_fs_value(self, inmemory_uploaded_file):
         return None
 
     def _parse_timestamps(self):
@@ -332,7 +332,7 @@ class FormDataParser(object):
 
     def _parse_value(self, value):
         if isinstance(value, FileUpload):
-            logger.debug("FileUpload wrapper - returning the gridfs dict!")
+            logger.debug("FileUpload wrapper - returning the fs dict!")
             return value.mongo_data
         elif isinstance(value, InMemoryUploadedFile):
             logger.debug("InMemoryUploadedFile returning None")
@@ -558,7 +558,7 @@ class DynamicDataWrapper(object):
             data[registry_model.code] = registry_data
 
         for registry_code in data:
-            wrap_gridfs_data_for_form(registry_model, data[registry_code])
+            wrap_fs_data_for_form(registry_model, data[registry_code])
         logger.debug("registry_specific_data after wrapping for files = %s" % data)
         return data
 
@@ -582,31 +582,31 @@ class DynamicDataWrapper(object):
 
     @staticmethod
     def handle_file_upload(registry_code, key, value, current_value):
+        to_delete = False
+        ret_value = value
         if value is False and current_value:
             # Django uses a "clear" checkbox value of False to indicate file should be removed
             # we need to delete the file but not here
             logger.debug("User cleared %s - file will be deleted" % key)
             to_delete = True
             file_ref = current_value
-            value = None
+            ret_value = None
         elif value is None:
             # No file upload means keep the current value
             logger.debug(
                 "User did not change file %s - existing_record will not be updated" % key)
             to_delete = None
-            value = current_value
+            ret_value = current_value
         elif is_uploaded_file(value):
             # A file was uploaded.
             # Store file and convert value into a file wrapper
             to_delete = False
-            value = filestorage.store_file_by_key(registry_code, None, key, value)
-        else:
-            to_delete = None
+            ret_value = filestorage.store_file_by_key(registry_code, None, key, value)
 
         if to_delete:
             filestorage.delete_file_wrapper(file_ref)
 
-        return value
+        return ret_value
 
     @classmethod
     def handle_file_uploads(cls, registry_code, key, value, current_value):
@@ -614,7 +614,7 @@ class DynamicDataWrapper(object):
                    val, cur in zip_longest(value, current_value or [])]
         return list(filter(bool, updated))
 
-    def _update_files_in_gridfs(self, existing_record, registry, new_data, index_map):
+    def _update_files_in_fs(self, existing_record, registry, new_data, index_map):
         for key, value in new_data.items():
             cde_code = get_code(key)
             if is_file_cde(cde_code):
@@ -740,7 +740,7 @@ class DynamicDataWrapper(object):
             record = self._make_record(registry, collection_name)
             record.data["forms"] = []
 
-        self._update_files_in_gridfs(record.data, registry, form_data, index_map)
+        self._update_files_in_fs(record.data, registry, form_data, index_map)
 
         nested_data = parse_form_data(Registry.objects.get(code=registry),
                                       self.current_form_model,

--- a/rdrf/rdrf/features/fh_file_upload.feature
+++ b/rdrf/rdrf/features/fh_file_upload.feature
@@ -1,8 +1,12 @@
 Feature: User uploads files.
   A user can:
+  CRUD operations on file cdes:
   Upload a file corresponding to a file CDE and be provided with a
-  download link for that file.
-  Delete an uploaded file.
+  download link for that file (CR)
+  Update an existing file cde with a new file (U)
+  Delete an uploaded file. (D)
+  
+  NB. The uploaded files are arbritrary - I chose some feature files for convenience.
   
   Background:
     Given export "fh.zip"
@@ -21,8 +25,46 @@ Feature: User uploads files.
     When I upload file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Laboratory Data" cde "Laboratory Report"
     And I click the "Save" button
     Then I should see "Patient John SMITH saved successfully"
-    #Then I should see "Currently:"
     Then I should be able to download "fh_file_upload.feature"
     
+
+  Scenario: Update (replace) an existing file cde.
+    When I am logged in as curator
+    When I click Module "Main/Genetic Data" for patient "SMITH John" on patientlisting
+    Then location is "Main/Genetic Data"
+   
+    # File cde is on genetic form where this cde is mandatory
+    When I click radio button value "Yes" for section "Genetic Analysis" cde "Has the patient had a DNA test?"
+    And I click the "Save" button
+    Then I should see "Patient John SMITH saved successfully"
     
-     
+    When I upload file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Laboratory Data" cde "Laboratory Report"
+    And I click the "Save" button
+    Then I should see "Patient John SMITH saved successfully"
+    Then I should be able to download "fh_file_upload.feature"
+    
+    When I upload file "/app/rdrf/rdrf/features/fh_family_linkage.feature" for multisection "Laboratory Data" cde "Laboratory Report"
+    And I click the "Save" button
+    Then I should see "Patient John SMITH saved successfully"
+    Then I should be able to download "fh_family_linkage.feature"
+    
+
+#  Scenario: Delete (check the 'clear' box and save) an existing file cde.
+#    When I am logged in as curator
+#    When I click Module "Main/Genetic Data" for patient "SMITH John" on patientlisting
+#    Then location is "Main/Genetic Data"
+#   
+#    # File cde is on genetic form where this cde is mandatory
+#    When I click radio button value "Yes" for section "Genetic Analysis" cde "Has the patient had a DNA test?"
+#    And I click the "Save" button
+#    Then I should see "Patient John SMITH saved successfully"
+#    
+#    When I upload file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Laboratory Data" cde "Laboratory Report"
+#    And I click the "Save" button
+#    Then I should see "Patient John SMITH saved successfully"
+#    Then I should be able to download "fh_file_upload.feature"
+#    
+#    When I check the clear checkbox for multisection "Laboratory Data" cde "Laboratory Report" file "fh_file_upload.feature"
+#    And I click the "Save" button
+#    Then I should see "Patient John SMITH saved successfully"
+#    #And I should not be able to download "fh_file_upload.feature"

--- a/rdrf/rdrf/features/fh_file_upload.feature
+++ b/rdrf/rdrf/features/fh_file_upload.feature
@@ -1,0 +1,28 @@
+Feature: User uploads files.
+  A user can:
+  Upload a file corresponding to a file CDE and be provided with a
+  download link for that file.
+  Delete an uploaded file.
+  
+  Background:
+    Given export "fh.zip"
+    Given a registry named "FH Registry"
+  
+  Scenario: Upload a file.
+    When I am logged in as curator
+    When I click Module "Main/Genetic Data" for patient "SMITH John" on patientlisting
+    Then location is "Main/Genetic Data"
+   
+    # File cde is on genetic form where this cde is mandatory
+    When I click radio button value "Yes" for section "Genetic Analysis" cde "Has the patient had a DNA test?"
+    And I click the "Save" button
+    Then I should see "Patient John SMITH saved successfully"
+    
+    When I upload file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Laboratory Data" cde "Laboratory Report"
+    And I click the "Save" button
+    Then I should see "Patient John SMITH saved successfully"
+    #Then I should see "Currently:"
+    Then I should be able to download "fh_file_upload.feature"
+    
+    
+     

--- a/rdrf/rdrf/file_upload.py
+++ b/rdrf/rdrf/file_upload.py
@@ -23,20 +23,20 @@ class FileUpload(object):
     :return:
     """
 
-    def __init__(self, registry, cde_code, gridfs_dict):
+    def __init__(self, registry, cde_code, fs_dict):
         if isinstance(registry, str):
             from rdrf.models import Registry
             self.registry = Registry.objects.get(code=registry)
         else:
             self.registry = registry
         self.cde_code = cde_code
-        self.gridfs_dict = gridfs_dict
+        self.fs_dict = fs_dict
 
     @property
     def url(self):
         kwargs = {
             "registry_code": self.registry.code,
-            "file_id": self.gridfs_dict.get("django_file_id"),
+            "file_id": self.fs_dict.get("django_file_id"),
         }
 
         if kwargs["file_id"]:
@@ -44,11 +44,11 @@ class FileUpload(object):
                 return reverse("file_upload", kwargs=kwargs)
             except NoReverseMatch:
                 logger.info("Couldn't make URL for file record %s" %
-                            str(self.gridfs_dict))
+                            str(self.fs_dict))
 
 
         logger.debug("FileUpload url property returning empty string?? kwargs = %s" % kwargs)
-        logger.debug("FileUpload gridfs_dict = %s" % self.gridfs_dict)
+        logger.debug("FileUpload fs_dict = %s" % self.fs_dict)
 
         return ""
 
@@ -57,20 +57,20 @@ class FileUpload(object):
         This is to satisfy Django's ClearableFileInputWidget which
         uses django's force_text function
         """
-        return self.gridfs_dict['file_name']
+        return self.fs_dict['file_name']
 
     @property
     def mongo_data(self):
-        return self.gridfs_dict
+        return self.fs_dict
 
 
-def wrap_gridfs_data_for_form(registry, data):
+def wrap_fs_data_for_form(registry, data):
     """
     :param data: Dynamic data loaded from Mongo
-    gridfs data is stored like this:
-    'cdecodeforfile': { "gridfs_file_id' : 82327 , file_name: 'some name' }
+    fs data is stored like this:
+    'cdecodeforfile': { "django_file_id' : 82327 , file_name: 'some name' }
 
-    :return: --  Munges the passed in dictionary and wraps any gridfs references with
+    :return: --  Munges the passed in dictionary and wraps any fs references with
     wrappers which display a download link to the file
     """
     def wrap(value, key):

--- a/rdrf/rdrf/file_upload.py
+++ b/rdrf/rdrf/file_upload.py
@@ -46,6 +46,10 @@ class FileUpload(object):
                 logger.info("Couldn't make URL for file record %s" %
                             str(self.gridfs_dict))
 
+
+        logger.debug("FileUpload url property returning empty string?? kwargs = %s" % kwargs)
+        logger.debug("FileUpload gridfs_dict = %s" % self.gridfs_dict)
+
         return ""
 
     def __str__(self):
@@ -177,15 +181,20 @@ def wrap_file_cdes(registry_code, section_data, mongo_data, multisection=False):
         # a multisection is just a list of section dicts indexed by
         # section_index
         if not should_wrap(section_index, key, value):
+            logger.debug("will NOT wrap %s" % key)
             return value
 
         if is_filestorage_dict(value):
+            logger.debug("will wrap file storage value %s" % value)
+
             return wrap_filestorage_dict(key, value)
 
         if is_upload_file(value):
+            logger.debug("will wrap upload file %s" % value)
             return wrap_upload(key, value)
 
         if is_existing_in_mongo(section_index, key, value):
+            logger.debug("will wrap existing key %s value %s" % (key, value))
             mongo_value = get_mongo_value(section_index, key)
             return wrap_filestorage_dict(key, mongo_value)
 

--- a/rdrf/rdrf/filestorage.py
+++ b/rdrf/rdrf/filestorage.py
@@ -15,7 +15,7 @@ def get_id(value):
     return None
 
 
-def delete_file_wrapper(fs, file_ref):
+def delete_file_wrapper(file_ref):
     django_file_id = file_ref.get("django_file_id")
     logger.debug("existing file ids: django = %s" % django_file_id)
 

--- a/rdrf/rdrf/form_view.py
+++ b/rdrf/rdrf/form_view.py
@@ -18,7 +18,7 @@ from .dynamic_forms import create_form_class_for_section
 from .dynamic_data import DynamicDataWrapper
 from django.http import Http404
 from .questionnaires import PatientCreator
-from .file_upload import wrap_gridfs_data_for_form
+from .file_upload import wrap_fs_data_for_form
 from .file_upload import wrap_file_cdes
 from . import filestorage
 from .utils import de_camelcase, location_name, is_multisection, make_index_map
@@ -709,7 +709,7 @@ class FormView(View):
 
             if not section_model.allow_multiple:
                 # return a normal form
-                initial_data = wrap_gridfs_data_for_form(self.registry, self.dynamic_data)
+                initial_data = wrap_fs_data_for_form(self.registry, self.dynamic_data)
                 form_section[s] = form_class(self.dynamic_data, initial=initial_data)
 
             else:
@@ -728,7 +728,7 @@ class FormView(View):
                 if self.dynamic_data:
                     try:
                         # we grab the list of data items by section code not cde code
-                        initial_data = wrap_gridfs_data_for_form(
+                        initial_data = wrap_fs_data_for_form(
                             self.registry, self.dynamic_data[s])
                     except KeyError as ke:
                         logger.error(

--- a/rdrf/rdrf/form_view.py
+++ b/rdrf/rdrf/form_view.py
@@ -132,7 +132,7 @@ class SectionInfo(object):
         self.data = data
         self.index_map = index_map
 
-    def save_to_mongo(self):
+    def save(self):
         if not self.is_multiple:
             self.patient_wrapper.save_dynamic_data(self.registry_code, self.collection_name, self.data)
         else:
@@ -470,7 +470,7 @@ class FormView(View):
         # Save one snapshot after all sections have being persisted
         if all_sections_valid:
             for section_info in sections_to_save:
-                section_info.save_to_mongo()
+                section_info.save()
 
             progress_dict = dyn_patient.save_form_progress(registry_code, context_model=self.rdrf_context)
 

--- a/rdrf/rdrf/registry_specific_fields.py
+++ b/rdrf/rdrf/registry_specific_fields.py
@@ -64,7 +64,7 @@ class RegistrySpecificFieldsHandler(object):
         else:
             return True
 
-    def _delete_existing_file_in_gridfs(self, file_cde_model):
+    def _delete_existing_file_in_fs(self, file_cde_model):
         existing_data = self.get_registry_specific_data()
         file_upload_wrapper = existing_data[self.registry_model.code][file_cde_model.code]
         filestorage.delete_file_wrapper(file_upload_wrapper)

--- a/scripts/old/patient_importer.py
+++ b/scripts/old/patient_importer.py
@@ -28,7 +28,7 @@ from registry.genetic.models import Gene
 from registry.genetic.models import Laboratory
 
 from rdrf.dynamic_data import DynamicDataWrapper
-from rdrf.file_upload import wrap_gridfs_data_for_form
+from rdrf.file_upload import wrap_fs_data_for_form
 
 import pycountry
 
@@ -280,8 +280,8 @@ class BaseMultiSectionHandler(object):
     def _save_multisection_to_mongo(self, rdrf_patient, converted_sections):
         self.importer.msg("saving list of section items to mongo %s" % converted_sections)
         registry_code = self.importer.registry.code
-        gridfs_wrapped_sections = wrap_gridfs_data_for_form(target_registry_code, converted_sections)
-        multisection_data = {self.SECTION_MODEL.code: gridfs_wrapped_sections}
+        fs_wrapped_sections = wrap_fs_data_for_form(target_registry_code, converted_sections)
+        multisection_data = {self.SECTION_MODEL.code: fs_wrapped_sections}
         ddw = DynamicDataWrapper(rdrf_patient)
         ddw.save_dynamic_data(registry_code, "cdes", multisection_data)
         self.importer.mongo_patient_ids.add(rdrf_patient.pk)


### PR DESCRIPTION
File CDEs allow a file to uploaded.
When uploaded a download  link should appear at the file cde location.
An uploaded file can be replaced by uploading another file.
An uploaded file can be deleted by checking a "clear" checkbox near the file link - when checked , the file storage module deletes the file.

Changes have been made to the underlying file storage mechanism which resulted in several issues 

The file link for a download was not displaying in the view's post response. ( this was a logic error in the view not the file storage change: the "wrapping" of file widgets was occurring too early so that no upload ids had been created at that stage) The fix was to do recreate the wrapped section forms at a later stage when the upload ids had been generated.

The clear checkbox didn't work and caused a runtime error ( filestorage api signature change)
Reuploading was broken ( ditto)


some aloe tests were written to test:

Uploading a file and observing that a download link was visible and of the right form ( /uploads/<upload_id> where the upload id is a django model pk - I test for the pattern because this indirectly checks that a model object has been created server side 

Replacing a file : same idea

I tried to get a delete/clear test working but couldn't so I've commented it out for now.

