### PR TITLE
Mark for deletion

### DIFF
--- a/rdrf/rdrf/dynamic_data.py
+++ b/rdrf/rdrf/dynamic_data.py
@@ -110,8 +110,12 @@ def update_multisection_file_cdes(registry_code,
         for key, value in section_item_dict.items():
             cde_code = get_code(key)
             if is_file_cde(cde_code):
+                actual_index = index_map[item_index]
+                
                 existing_value = get_mongo_value(registry_code, existing_nested_data, key,
-                                                 multisection_index=item_index)
+                                                 multisection_index=actual_index)
+
+                # antecedent here will never return true and the definition is not correct
                 if is_multiple_file_cde(cde_code):
                     new_val = DynamicDataWrapper.handle_file_uploads(registry_code, key, value, existing_value)
                 else:
@@ -582,6 +586,10 @@ class DynamicDataWrapper(object):
 
     @staticmethod
     def handle_file_upload(registry_code, key, value, current_value):
+        logger.debug("handle_file_upload: key = %s value = %s current_value = %s" % (key,
+                                                                                     value,
+                                                                                     current_value))
+        
         to_delete = False
         ret_value = value
         if value is False and current_value:

--- a/rdrf/rdrf/features/fh_file_upload.feature
+++ b/rdrf/rdrf/features/fh_file_upload.feature
@@ -22,7 +22,7 @@ Feature: User uploads files.
     And I click the "Save" button
     Then I should see "Patient John SMITH saved successfully"
     
-    When I upload file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Laboratory Data" cde "Laboratory Report"
+    When I upload file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Laboratory Data" cde "Laboratory Report" in item 1
     And I click the "Save" button
     Then I should see "Patient John SMITH saved successfully"
     Then I should be able to download "fh_file_upload.feature"
@@ -38,12 +38,12 @@ Feature: User uploads files.
     And I click the "Save" button
     Then I should see "Patient John SMITH saved successfully"
     
-    When I upload file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Laboratory Data" cde "Laboratory Report"
+    When I upload file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Laboratory Data" cde "Laboratory Report" in item 1
     And I click the "Save" button
     Then I should see "Patient John SMITH saved successfully"
     Then I should be able to download "fh_file_upload.feature"
     
-    When I upload file "/app/rdrf/rdrf/features/fh_family_linkage.feature" for multisection "Laboratory Data" cde "Laboratory Report"
+    When I upload file "/app/rdrf/rdrf/features/fh_family_linkage.feature" for multisection "Laboratory Data" cde "Laboratory Report" in item 1
     And I click the "Save" button
     Then I should see "Patient John SMITH saved successfully"
     Then I should be able to download "fh_family_linkage.feature"

--- a/rdrf/rdrf/features/fh_multisection_tests.feature
+++ b/rdrf/rdrf/features/fh_multisection_tests.feature
@@ -32,8 +32,8 @@ Feature: User operates on multisection items.
     #And I enter value "3.0" for form "Imaging" section "Carotid Ultrasonography" cde "Result (left)"
     And I enter value "3.0" for form "Imaging" section "Carotid Ultrasonography" cde "Result (right)" in item 2
     And I enter value "item 2" for form "Imaging" section "Carotid Ultrasonography" cde "Result" in item 2
-    When I upload file "/app/rdrf/rdrf/features/fh_multisection_tests.feature" for multisection "Carotid Ultrasonography" cde "Report" in item 2
+    When I upload2 file "/app/rdrf/rdrf/features/fh_multisection_tests.feature" for multisection "Carotid Ultrasonography" cde "Report" in item 2
     And I click the "Save" button
     Then I should see "Patient John SMITH saved successfully"
     And I should be able to download "fh_multisection_tests.feature"
-    #And I should be able to download "fh_file_upload.feature"
+    And I should be able to download "fh_file_upload.feature"

--- a/rdrf/rdrf/features/fh_multisection_tests.feature
+++ b/rdrf/rdrf/features/fh_multisection_tests.feature
@@ -1,0 +1,39 @@
+Feature: User operates on multisection items.
+  A user can:
+  Add items (single section data) to a multisection and delete an item
+  by checking the "Mark for Deletion" checkbox and saving.
+  
+  Background:
+    Given export "fh.zip"
+    Given a registry named "FH Registry"
+  
+  Scenario: Add multiple items to a multisection.
+    When I am logged in as curator
+    When I click Module "Main/Imaging" for patient "SMITH John" on patientlisting
+    Then location is "Main/Imaging"
+  
+    # Enter first item
+    #When I click radio button value "Yes - Normal" for section "Carotid Ultrasonography" cde "Carotid Ultrasonography"
+    And I enter value "01-01-2017" for form "Imaging" section "Carotid Ultrasonography" cde "Date"
+    # for some reason the line below failed
+    #And I enter value "3.0" for form "Imaging" section "Carotid Ultrasonography" cde "Result (left)"
+    And I enter value "4.0" for form "Imaging" section "Carotid Ultrasonography" cde "Result (right)"
+    And I enter value "item 1" for form "Imaging" section "Carotid Ultrasonography" cde "Result"
+    When I upload file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Carotid Ultrasonography" cde "Report"
+    And I click the "Save" button
+    Then I should see "Patient John SMITH saved successfully"
+    And I should be able to download "fh_file_upload.feature"
+
+    # Enter second item
+    #When I click radio button value "Yes - Normal" for section "Carotid Ultrasonography" cde "Carotid Ultrasonography"
+    When I click the add button for multisection "Carotid Ultrasonography"
+    And I enter value "02-01-2017" for form "Imaging" section "Carotid Ultrasonography" cde "Date" in item 2
+    # for some reason the line below failed
+    #And I enter value "3.0" for form "Imaging" section "Carotid Ultrasonography" cde "Result (left)"
+    And I enter value "3.0" for form "Imaging" section "Carotid Ultrasonography" cde "Result (right)" in item 2
+    And I enter value "item 2" for form "Imaging" section "Carotid Ultrasonography" cde "Result" in item 2
+    When I upload file "/app/rdrf/rdrf/features/fh_multisection_tests.feature" for multisection "Carotid Ultrasonography" cde "Report" in item 2
+    And I click the "Save" button
+    Then I should see "Patient John SMITH saved successfully"
+    And I should be able to download "fh_multisection_tests.feature"
+    #And I should be able to download "fh_file_upload.feature"

--- a/rdrf/rdrf/features/fh_multisection_tests.feature
+++ b/rdrf/rdrf/features/fh_multisection_tests.feature
@@ -37,3 +37,7 @@ Feature: User operates on multisection items.
     And I click the "Save" button
     Then I should not be able to download "fh_file_upload.feature"
     And I should be able to download "fh_multisection_tests.feature"
+    
+    # check some values - we deleted the 1st item so what remains is the original 2nd item
+    And the value of multisection "Carotid Ultrasonography" cde "Date" item 1 is "02-01-2017"
+    And the value of multisection "Carotid Ultrasonography" cde "Result" item 1 is "item 2"

--- a/rdrf/rdrf/features/fh_multisection_tests.feature
+++ b/rdrf/rdrf/features/fh_multisection_tests.feature
@@ -16,7 +16,7 @@ Feature: User operates on multisection items.
     And I enter value "01-01-2017" for form "Imaging" multisection "Carotid Ultrasonography" cde "Date" in item 1  
     And I enter value "4.0" for form "Imaging" multisection "Carotid Ultrasonography" cde "Result (right)" in item 1
     And I enter value "item 1" for form "Imaging" multisection "Carotid Ultrasonography" cde "Result" in item 1
-    When I upload2 file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Carotid Ultrasonography" cde "Report" in item 1
+    When I upload file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Carotid Ultrasonography" cde "Report" in item 1
     And I click the "Save" button
     Then I should see "Patient John SMITH saved successfully"
     And I should be able to download "fh_file_upload.feature"
@@ -26,7 +26,7 @@ Feature: User operates on multisection items.
     And I enter value "02-01-2017" for form "Imaging" multisection "Carotid Ultrasonography" cde "Date" in item 2
     And I enter value "3.0" for form "Imaging" multisection "Carotid Ultrasonography" cde "Result (right)" in item 2
     And I enter value "item 2" for form "Imaging" multisection "Carotid Ultrasonography" cde "Result" in item 2
-    When I upload2 file "/app/rdrf/rdrf/features/fh_multisection_tests.feature" for multisection "Carotid Ultrasonography" cde "Report" in item 2
+    When I upload file "/app/rdrf/rdrf/features/fh_multisection_tests.feature" for multisection "Carotid Ultrasonography" cde "Report" in item 2
     And I click the "Save" button
     Then I should see "Patient John SMITH saved successfully"
     And I should be able to download "fh_multisection_tests.feature"

--- a/rdrf/rdrf/features/fh_multisection_tests.feature
+++ b/rdrf/rdrf/features/fh_multisection_tests.feature
@@ -37,3 +37,9 @@ Feature: User operates on multisection items.
     Then I should see "Patient John SMITH saved successfully"
     And I should be able to download "fh_multisection_tests.feature"
     And I should be able to download "fh_file_upload.feature"
+   
+    # delete the first item of the multisection
+    When I mark multisection "Carotid Ultrasonography" item 1 for deletion
+    And I click the "Save" button
+    And I should not be able to download "fh_file_upload.feature"
+    And I should be able to download "fh_multisection_tests.feature"

--- a/rdrf/rdrf/features/fh_multisection_tests.feature
+++ b/rdrf/rdrf/features/fh_multisection_tests.feature
@@ -13,25 +13,19 @@ Feature: User operates on multisection items.
     Then location is "Main/Imaging"
   
     # Enter first item
-    #When I click radio button value "Yes - Normal" for section "Carotid Ultrasonography" cde "Carotid Ultrasonography"
-    And I enter value "01-01-2017" for form "Imaging" section "Carotid Ultrasonography" cde "Date"
-    # for some reason the line below failed
-    #And I enter value "3.0" for form "Imaging" section "Carotid Ultrasonography" cde "Result (left)"
-    And I enter value "4.0" for form "Imaging" section "Carotid Ultrasonography" cde "Result (right)"
-    And I enter value "item 1" for form "Imaging" section "Carotid Ultrasonography" cde "Result"
-    When I upload file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Carotid Ultrasonography" cde "Report"
+    And I enter value "01-01-2017" for form "Imaging" multisection "Carotid Ultrasonography" cde "Date" in item 1  
+    And I enter value "4.0" for form "Imaging" multisection "Carotid Ultrasonography" cde "Result (right)" in item 1
+    And I enter value "item 1" for form "Imaging" multisection "Carotid Ultrasonography" cde "Result" in item 1
+    When I upload2 file "/app/rdrf/rdrf/features/fh_file_upload.feature" for multisection "Carotid Ultrasonography" cde "Report" in item 1
     And I click the "Save" button
     Then I should see "Patient John SMITH saved successfully"
     And I should be able to download "fh_file_upload.feature"
 
     # Enter second item
-    #When I click radio button value "Yes - Normal" for section "Carotid Ultrasonography" cde "Carotid Ultrasonography"
     When I click the add button for multisection "Carotid Ultrasonography"
-    And I enter value "02-01-2017" for form "Imaging" section "Carotid Ultrasonography" cde "Date" in item 2
-    # for some reason the line below failed
-    #And I enter value "3.0" for form "Imaging" section "Carotid Ultrasonography" cde "Result (left)"
-    And I enter value "3.0" for form "Imaging" section "Carotid Ultrasonography" cde "Result (right)" in item 2
-    And I enter value "item 2" for form "Imaging" section "Carotid Ultrasonography" cde "Result" in item 2
+    And I enter value "02-01-2017" for form "Imaging" multisection "Carotid Ultrasonography" cde "Date" in item 2
+    And I enter value "3.0" for form "Imaging" multisection "Carotid Ultrasonography" cde "Result (right)" in item 2
+    And I enter value "item 2" for form "Imaging" multisection "Carotid Ultrasonography" cde "Result" in item 2
     When I upload2 file "/app/rdrf/rdrf/features/fh_multisection_tests.feature" for multisection "Carotid Ultrasonography" cde "Report" in item 2
     And I click the "Save" button
     Then I should see "Patient John SMITH saved successfully"
@@ -41,5 +35,5 @@ Feature: User operates on multisection items.
     # delete the first item of the multisection
     When I mark multisection "Carotid Ultrasonography" item 1 for deletion
     And I click the "Save" button
-    And I should not be able to download "fh_file_upload.feature"
+    Then I should not be able to download "fh_file_upload.feature"
     And I should be able to download "fh_multisection_tests.feature"

--- a/rdrf/rdrf/features/steps.py
+++ b/rdrf/rdrf/features/steps.py
@@ -605,6 +605,22 @@ def should_be_able_to_download(step, download_name):
         raise Exception("%s does not look like a download link: href= %s" %
                         download_link_href)
 
+@step('should not be able to download "(.*)"')
+def should_not_be_able_download(step, download_name):
+    can_download = False
+    try:
+        should_be_able_to_download(step, download_name)
+        can_download = True
+    except:
+        pass
+
+    if can_download:
+        raise Exception("should NOT be able to download %s" % download_name)
+    else:
+        print("%s is not downloadable as expected" % download_name)
+        
+
+
 @step('History for form "(.*)" section "(.*)" cde "(.*)" shows "(.*)"')
 def check_history_popup(step, form, section, cde, history_values_csv):
     from selenium.webdriver.common.action_chains import ActionChains
@@ -711,6 +727,30 @@ def wait_n_seconds(step, seconds):
     import time
     n = int(seconds)
     time.sleep(n)
+
+
+@step('I mark multisection "(.*)" item (\d+) for deletion')
+def mark_item_for_deletion(step, multisection, item):
+    formset_string = "-%s-" % (int(item) - 1)
+    xpath = "//div[@class='panel-heading' and contains(., '%s')]" % multisection
+    default_panel = world.browser.find_element_by_xpath(xpath).find_element_by_xpath("..")
+    # now locate the delete checkbox for the item
+    checkbox_xpath = ".//input[@type='checkbox' and contains(@id, '-DELETE') and contains(@id, '%s')]" % formset_string
+    delete_checkbox = default_panel.find_element_by_xpath(checkbox_xpath)
+    
+    if delete_checkbox:
+        print("found delete_checkbox for multisection %s item %s" % (multisection,
+                                                                     item))
+    else:
+        raise Exception("Could not found delete checkbox for multisection %s item %s" % (multisection,
+                                                                                         item))
+
+    scroll_to(delete_checkbox)
+    delete_checkbox.click()
+    
+
+
+
   
 
     

--- a/rdrf/rdrf/features/steps.py
+++ b/rdrf/rdrf/features/steps.py
@@ -720,6 +720,9 @@ def add_multisection_item(step, section):
   add_link_xpath = """.//a[starts-with(@onclick,"add_form('formset_")]"""
   add_link = div.find_element_by_xpath(add_link_xpath)
   add_link.click()
+  # sometimes the next cde send keys was going to the wrong item
+  wait_n_seconds(step, 5)
+  
 
 
 @step('I wait (\d+) seconds')

--- a/rdrf/rdrf/features/steps.py
+++ b/rdrf/rdrf/features/steps.py
@@ -45,26 +45,41 @@ def scroll_to(element):
 
 def scroll_to_multisection_cde(section, cde, item=1):
     # item 1 means the 1st block of cdes in the multisection
+    print("Attempting to scroll to section %s cde %s item %s" % (section,
+                                                                 cde,
+                                                                 item))
+    
     formset_string = "-%s-" % (int(item) - 1)
+    print("formset_string = %s" % formset_string)
     if item == 1:
         # the first (default) item is not created by js from the empty form template
         contains_clause = " not(contains(,, '__prefix__')) "
     else:
         # subsequent items are ...
         contains_clause = " contains(., '__prefix__') "
+
+    print("contains clause = %s" % contains_clause)
+    xpath = "//div[@class='panel-heading' and contains(., '%s')]" % section
+    default_panel = world.browser.find_element_by_xpath(xpath).find_element_by_xpath("..")
     
-    for section_div_heading in world.browser.find_elements_by_xpath(".//div[@class='panel-heading'][contains(., '%s') " + 
-                                                                    " and %s]" % (section,
-                                                                                  contains_clause)):
-        
-        section_div = section_div_heading.find_element_by_xpath("..")
-        label_expression = ".//label[contains(., '%s')]" % cde
-        label_element = section_div.find_element_by_xpath(label_expression)
+    label_expression = ".//label[contains(., '%s')]" % cde
+    
+    for label_element in default_panel.find_elements_by_xpath(label_expression):
+        print("found a label element for cde %s" % cde)
         input_div = label_element.find_element_by_xpath(".//following-sibling::div")
-        input_element = input_div.find_element_by_xpath(".//input[@id=*'%s']" % formset_string)
+        try:
+            input_element = input_div.find_element_by_xpath(".//input[contains(@id, '%s')]" % formset_string)
+        except:
+            input_element = None
+            
         if not input_element:
+            print("The input element is not in the correct formset - continuing to search...")
             continue
-        scroll_to_element(input_element)
+        else:
+            print("found input element for cde %s in item %s" % (cde, item))
+            
+        scroll_to(input_element)
+        print("found input element: id = %s" % input_element.get_attribute("id"))
         return input_element
 
     raise Exception("Could not locate multsection %s cde %s item %s" % (section,
@@ -550,7 +565,7 @@ def upload_file(step, upload_filename, section, cde):
     input_element = scroll_to_element(step, section, cde)
     input_element.send_keys(upload_filename)
 
-@step('upload file "(.*)" for section "(.*)" cde "(.*)" in item (\d+)')
+@step('upload2 file "(.*)" for multisection "(.*)" cde "(.*)" in item (\d+)')
 def upload_file(step, upload_filename, section, cde, item):
     input_element = scroll_to_multisection_cde(section, cde, item)
     input_element.send_keys(upload_filename)

--- a/rdrf/rdrf/features/steps.py
+++ b/rdrf/rdrf/features/steps.py
@@ -422,7 +422,7 @@ def click_radio_button(step, value, section, cde):
     input_element  = input_div.find_element_by_xpath(".//input")
     input_element.click()
 
-@step('upload2 file "(.*)" for multisection "(.*)" cde "(.*)" in item (\d+)')
+@step('upload file "(.*)" for multisection "(.*)" cde "(.*)" in item (\d+)')
 def upload_file(step, upload_filename, section, cde, item):
     input_element = utils.scroll_to_multisection_cde(section, cde, item)
     input_element.send_keys(upload_filename)
@@ -489,13 +489,7 @@ def check_history_popup(step, form, section, cde, history_values_csv):
     input_element = input_div.find_element_by_xpath(".//input")
     history_widget = label_element.find_elements_by_xpath(".//a[@onclick='rdrf_click_form_field_history(event, this)']")[0]
 
-    # scroll down to the correct input element
-    loc = input_element.location_once_scrolled_into_view
-    y = loc["y"]
-    world.browser.execute_script("window.scrollTo(0, %s)" % y)
-
     utils.scroll_to(input_element)
-    
 
     # this causes the history component to become visible/clickable
     mover = ActionChains(world.browser)

--- a/rdrf/rdrf/features/steps.py
+++ b/rdrf/rdrf/features/steps.py
@@ -603,6 +603,21 @@ def mark_item_for_deletion(step, multisection, item):
 
     utils.click(delete_checkbox)
 
+@step('the value of multisection "(.*)" cde "(.*)" item (\d+) is "(.*)"')
+def check_multisection_value(step, multisection, cde, item, expected_value):
+    """
+    Check the value of an entered field in a multisection
+    """
+    input_element = utils.scroll_to_multisection_cde(multisection, cde, item)
+    actual_value = input_element.get_attribute("value")
+    error_msg = "Multisection %s cde %s item %s expected value %s - actual value %s" % (multisection,
+                                                                                  cde,
+                                                                                  item,
+                                                                                  expected_value,
+                                                                                  actual_value)
+    
+    assert(actual_value == expected_value, error_msg)
+
 
   
 

--- a/rdrf/rdrf/features/steps.py
+++ b/rdrf/rdrf/features/steps.py
@@ -41,6 +41,40 @@ def scroll_to(element):
      scroll_to_y(y)
      print("scrolled to %s at (0,Y) = %s" % (moniker(element), y))
      return y
+
+
+def scroll_to_multisection_cde(section, cde, item=1):
+    # item 1 means the 1st block of cdes in the multisection
+    formset_string = "-%s-" % (int(item) - 1)
+    if item == 1:
+        # the first (default) item is not created by js from the empty form template
+        contains_clause = " not(contains(,, '__prefix__')) "
+    else:
+        # subsequent items are ...
+        contains_clause = " contains(., '__prefix__') "
+    
+    for section_div_heading in world.browser.find_elements_by_xpath(".//div[@class='panel-heading'][contains(., '%s') " + 
+                                                                    " and %s]" % (section,
+                                                                                  contains_clause)):
+        
+        section_div = section_div_heading.find_element_by_xpath("..")
+        label_expression = ".//label[contains(., '%s')]" % cde
+        label_element = section_div.find_element_by_xpath(label_expression)
+        input_div = label_element.find_element_by_xpath(".//following-sibling::div")
+        input_element = input_div.find_element_by_xpath(".//input[@id=*'%s']" % formset_string)
+        if not input_element:
+            continue
+        scroll_to_element(input_element)
+        return input_element
+
+    raise Exception("Could not locate multsection %s cde %s item %s" % (section,
+                                                                        cde,
+                                                                        item))
+
+
+        
+        
+    
  
 
 def scroll_to_cde(section, cde, attr_dict={},multisection=False, item=None):
@@ -518,7 +552,7 @@ def upload_file(step, upload_filename, section, cde):
 
 @step('upload file "(.*)" for section "(.*)" cde "(.*)" in item (\d+)')
 def upload_file(step, upload_filename, section, cde, item):
-    input_element = scroll_to_cde(section, cde, item=item)
+    input_element = scroll_to_multisection_cde(section, cde, item)
     input_element.send_keys(upload_filename)
     
 @step('upload file "(.*)" for multisection "(.*)" cde "(.*)"')

--- a/rdrf/rdrf/features/utils.py
+++ b/rdrf/rdrf/features/utils.py
@@ -204,16 +204,10 @@ def scroll_to_multisection_cde(section, cde, item=1):
     # item 1 means the 1st block of cdes in the multisection
     print("Attempting to scroll to section %s cde %s item %s" % (section,
                                                                  cde,
+
                                                                  item))
     formset_string = "-%s-" % (int(item) - 1)
     print("formset_string = %s" % formset_string)
-    if item == 1:
-        # the first (default) item is not created by js from the empty form template
-        contains_clause = " not(contains(,, '__prefix__')) "
-    else:
-        # subsequent items are ...
-        contains_clause = " contains(., '__prefix__') "
-
     xpath = "//div[@class='panel-heading' and contains(., '%s')]" % section
     default_panel = world.browser.find_element_by_xpath(xpath).find_element_by_xpath("..")
     label_expression = ".//label[contains(., '%s')]" % cde
@@ -221,17 +215,14 @@ def scroll_to_multisection_cde(section, cde, item=1):
     for label_element in default_panel.find_elements_by_xpath(label_expression):
         print("found a label element for cde %s" % cde)
         input_div = label_element.find_element_by_xpath(".//following-sibling::div")
+        # NB. We avoid matching against the clear checkbox for an uploaded file cde
         try:
-            input_element = input_div.find_element_by_xpath(".//input[contains(@id, '%s')]" % formset_string)
+            input_element = input_div.find_element_by_xpath(".//input[contains(@id, '%s') and not(contains(@id, '-clear_id'))]" % formset_string)
+            scroll_to(input_element)
+            print("found input element: id = %s" % input_element.get_attribute("id"))
+            return input_element
         except:
-            input_element = None
-            
-        if not input_element:
             continue
-            
-        scroll_to(input_element)
-        print("found input element: id = %s" % input_element.get_attribute("id"))
-        return input_element
 
     raise Exception("Could not locate multsection %s cde %s item %s" % (section,
                                                                         cde,

--- a/rdrf/rdrf/features/utils.py
+++ b/rdrf/rdrf/features/utils.py
@@ -189,3 +189,92 @@ def click(element):
 def debug_links():
     for link in world.browser.find_elements_by_xpath('//a'):
         logger.debug('link {0} {1}'.format(link.text, link.get_attribute("href")))
+
+def scroll_to_y(y):
+    world.browser.execute_script("window.scrollTo(0, %s)" % y)
+
+def scroll_to(element):
+     loc = element.location_once_scrolled_into_view
+     y = loc["y"]
+     scroll_to_y(y)
+     return y
+
+
+def scroll_to_multisection_cde(section, cde, item=1):
+    # item 1 means the 1st block of cdes in the multisection
+    print("Attempting to scroll to section %s cde %s item %s" % (section,
+                                                                 cde,
+                                                                 item))
+    formset_string = "-%s-" % (int(item) - 1)
+    print("formset_string = %s" % formset_string)
+    if item == 1:
+        # the first (default) item is not created by js from the empty form template
+        contains_clause = " not(contains(,, '__prefix__')) "
+    else:
+        # subsequent items are ...
+        contains_clause = " contains(., '__prefix__') "
+
+    xpath = "//div[@class='panel-heading' and contains(., '%s')]" % section
+    default_panel = world.browser.find_element_by_xpath(xpath).find_element_by_xpath("..")
+    label_expression = ".//label[contains(., '%s')]" % cde
+    
+    for label_element in default_panel.find_elements_by_xpath(label_expression):
+        print("found a label element for cde %s" % cde)
+        input_div = label_element.find_element_by_xpath(".//following-sibling::div")
+        try:
+            input_element = input_div.find_element_by_xpath(".//input[contains(@id, '%s')]" % formset_string)
+        except:
+            input_element = None
+            
+        if not input_element:
+            continue
+            
+        scroll_to(input_element)
+        print("found input element: id = %s" % input_element.get_attribute("id"))
+        return input_element
+
+    raise Exception("Could not locate multsection %s cde %s item %s" % (section,
+                                                                        cde,
+                                                                        item))
+
+def scroll_to_cde(section, cde):
+    """
+    navigate to a given section and cde, scrolling to make the field visible
+    return the input element
+    """
+    input_element = None
+    section_div_heading = world.browser.find_element_by_xpath(
+        ".//div[@class='panel-heading'][contains(., '%s') and not(contains(.,'__prefix__'))]" % section)
+
+    section_div = section_div_heading.find_element_by_xpath("..")
+    
+    label_expression = ".//label[contains(., '%s')]" % cde
+    label_element = section_div.find_element_by_xpath(label_expression)
+    input_div = label_element.find_element_by_xpath(".//following-sibling::div")
+    input_elements = input_div.find_elements_by_xpath(".//input")
+
+    if len(input_elements) >= 0:
+        if not item:
+            input_element = input_elements[0]
+        else:
+            formset_string = "-%s-" % (int(item) - 1)
+            for ie in input_elements:
+                input_id = ie.get_attribute("id")
+                if formset_string in input_id:
+                    input_element = ie
+                    break
+            raise Exception("Could not locate section %s input %s item %s" % (section, cde, item))
+            
+    if not input_element:
+        raise Exception("could not locate element to scroll to")
+    input_id = input_element.get_attribute("id")
+    if "__prefix__" in input_id:
+        # hack to avoid this error
+        input_id = input_id.replace("__prefix__","0")
+        input_element = world.browser.find_element_by_id(input_id)
+        if not input_element:
+            raise Exception("could not locate input with id %s" % input_id)
+
+    scroll_to(input_element)
+    return input_element
+

--- a/rdrf/rdrf/file_upload.py
+++ b/rdrf/rdrf/file_upload.py
@@ -59,10 +59,6 @@ class FileUpload(object):
         """
         return self.fs_dict['file_name']
 
-    def __unicode__(self):
-        return self.fs_dict['file_name']
-        
-
     @property
     def mongo_data(self):
         return self.fs_dict

--- a/rdrf/rdrf/file_upload.py
+++ b/rdrf/rdrf/file_upload.py
@@ -59,6 +59,10 @@ class FileUpload(object):
         """
         return self.fs_dict['file_name']
 
+    def __unicode__(self):
+        return self.fs_dict['file_name']
+        
+
     @property
     def mongo_data(self):
         return self.fs_dict
@@ -88,7 +92,7 @@ def wrap_fs_data_for_form(registry, data):
     return wrap(data, None)
 
 
-def wrap_file_cdes(registry_code, section_data, mongo_data, multisection=False):
+def wrap_file_cdes(registry_code, section_data, mongo_data, multisection=False,index_map={}):
     # Wrap file cde data for display in the form
     # I've refactored the code trying to make it as explicit as possible but it
     # would  still be good to refactor later as it is very painful
@@ -99,7 +103,7 @@ def wrap_file_cdes(registry_code, section_data, mongo_data, multisection=False):
     # File CDEs are stored as dictionaries in Mongo : {"django_file_id": <fileid> , "name": <filename>}.
     # The filestorage module handles the actual file content and retrieval.
 
-    # If no file has been uploaded mongo will contain the value None.
+    # If no file has been uploaded modjgo data will contain the value None.
 
     # In the gui , the widget for a file cde shows a download link and a clear checkbox.
     # The download link is created by a wrapper class: "FileUpload".
@@ -145,18 +149,39 @@ def wrap_file_cdes(registry_code, section_data, mongo_data, multisection=False):
                 return False
 
     def should_wrap(section_index, key, value):
+        logger.debug("in should_wrap: section_index %s key = %s value = %s" % (section_index,
+                                                                               key,
+                                                                               value))
+        
         try:
             cde_code = get_code(key)
+            logger.debug("cde_code = %s" % cde_code)
         except:
             # not a delimited mongo key
+            logger.debug("key %s is not delimited so returning False" % key)
             return False
 
         if is_file_cde(cde_code):
+            logger.debug("cde_code %s is a file cde" % cde_code)
             u = is_upload_file(value)
+            if u:
+                logger.debug("cde %s is an upload file u = %s" % (cde_code, u))
+    
             fs = is_filestorage_dict(value)
+            if fs:
+                logger.debug("value %s is a filestorage dict fs = %s" % (value, fs))
             im = is_existing_in_mongo(section_index, key, value)
-            return u or fs or im
+            if im:
+                logger.debug("value exists in db im = %s" %   im)
 
+                
+            sw = u or fs or im
+            logger.debug("should_wrap returns %s" % sw)
+            return sw
+        
+
+        
+        logger.debug("cde_code %s is not a file CDE so returning False" % cde_code)
         return False
 
     def wrap_upload(key, value):
@@ -166,6 +191,9 @@ def wrap_file_cdes(registry_code, section_data, mongo_data, multisection=False):
         return FileUpload(registry_code, key, value)
 
     def get_mongo_value(section_index, key):
+        logger.debug("get_mongo_value for section_index %s key %s" % (section_index,
+                                                                      key))
+        
         if section_index is None:
             value = mongo_data[key]
         else:
@@ -173,6 +201,10 @@ def wrap_file_cdes(registry_code, section_data, mongo_data, multisection=False):
             section_dicts = mongo_data[section_code]
             correct_section_dict = section_dicts[section_index]
             value = correct_section_dict[key]
+            logger.debug("section code %s correct_section_dict = %s value = %s" % (section_code,
+                                                                                   correct_section_dict,
+                                                                                   value))
+            
 
         return value
 
@@ -180,6 +212,7 @@ def wrap_file_cdes(registry_code, section_data, mongo_data, multisection=False):
         # NB we need section index in case we're looking inside a multisection
         # a multisection is just a list of section dicts indexed by
         # section_index
+        logger.debug("in wrap section_index %s key %s value %s" % (section_index, key, value))
         if not should_wrap(section_index, key, value):
             logger.debug("will NOT wrap %s" % key)
             return value
@@ -202,7 +235,34 @@ def wrap_file_cdes(registry_code, section_data, mongo_data, multisection=False):
         return {key: wrap(section_index, key, value) for key, value in section_dict.items()}
 
     def wrap_multisection(multisection_list):
-        return [wrap_section(section_index, section_dict) for section_index, section_dict in enumerate(multisection_list)]
+        def iterate_over_non_deleted_items(multisection_list):
+            # _if_ we have deleted items in the GUI, the passed in index_map
+            # holds a map of new index --> original source index
+            # so len(index_map.keys()) is the current number of items in the multisection
+            # e.g.
+            #  original items were A,B,C
+            #  and we deleted item 2 (index 1) to produce A,C
+            # index map would be {0: 0 ,
+            #                     1: 2}
+            # meaning that the first item hasn't changed but the 2nd item was originally 3rd
+             
+            # If C had a value of None for the file cde  this means we need to retrieve
+            # the django  file id from the DB ,
+            # but because we have deleted the second item and thus changed the index from 2 to 1
+            # it would be an error to wrap the value of db item with index 1 - rather we need to
+            # retieve the item using the old index  (2) ( which is preserved in the index_map dictionary
+            # and we should extract _that_ to wrap for the form
+            for new_index, item in enumerate(multisection_list):
+                if index_map:
+                    logger.debug("index_map non empty so retrieving old index")
+                    index = index_map[new_index]
+                else:
+                    logger.debug("index map is empty so using new index")
+                    index = new_index
+
+                yield index, item
+            
+        return [wrap_section(section_index, section_dict) for section_index, section_dict in iterate_over_non_deleted_items(multisection_list)]
 
     if multisection:
         return wrap_multisection(section_data)

--- a/rdrf/rdrf/form_view.py
+++ b/rdrf/rdrf/form_view.py
@@ -156,10 +156,6 @@ class SectionInfo(object):
         if not self.is_multiple:
             self.patient_wrapper.save_dynamic_data(self.registry_code, self.collection_name, self.data)
         else:
-            logger.debug("section info saving multisection for section %s" % self.section_code)
-            logger.debug("data to save = %s index map = %s" % (self.data,
-                                                               self.index_map))
-            
             self.patient_wrapper.save_dynamic_data(self.registry_code,
                                                    self.collection_name,
                                                    self.data,
@@ -169,19 +165,13 @@ class SectionInfo(object):
     def recreate_form_instance(self):
         # called when all sections on a form are valid
         # We do this to create a form instance which has correct links to uploaded files
-        logger.debug("recreating form instance for section %s" % self.section_code)
-
         current_data = self.patient_wrapper.load_dynamic_data(self.registry_code, "cdes")
         if self.is_multiple:
             dynamic_data = self.data[self.section_code] # the cleaned data from the form submission
         else:
             dynamic_data = self.data
-
-        logger.debug("current data loaded by sectioninfo: %s" % dynamic_data)
-        
                     
         wrapped_data = wrap_file_cdes(self.registry_code, dynamic_data, current_data, multisection=self.is_multiple)
-        logger.debug("wrapped data in section info:" % wrapped_data)
 
         if self.is_multiple:
             form_instance = self.form_set_class(initial=wrapped_data, prefix=self.prefix)
@@ -189,8 +179,6 @@ class SectionInfo(object):
             form_instance = self.form_class(dynamic_data, initial=wrapped_data)
 
         return form_instance
-
-
 
 class FormView(View):
 
@@ -236,9 +224,6 @@ class FormView(View):
 
             if self.rdrf_context is None:
                 raise RDRFContextSwitchError
-            else:
-                logger.debug("switched context for patient %s to context %s" % (patient_model,
-                                                                                self.rdrf_context.id))
 
         except RDRFContextError as ex:
             logger.error("Error setting rdrf context id %s for patient %s in %s: %s" % (context_id,
@@ -319,8 +304,6 @@ class FormView(View):
 
         if not self.CREATE_MODE:
             rdrf_context_id = self.rdrf_context.pk
-            logger.debug("********** RDRF CONTEXT ID SET TO %s" % rdrf_context_id)
-
             self.dynamic_data = self._get_dynamic_data(id=patient_id,
                                                        registry_code=registry_code,
                                                        rdrf_context_id=rdrf_context_id)
@@ -453,18 +436,14 @@ class FormView(View):
 
             if not section_model.allow_multiple:
                 form = form_class(request.POST, files=request.FILES)
-                logger.debug("validating form for section %s" % section_model)
                 if form.is_valid():
-                    logger.debug("form is valid")
                     dynamic_data = form.cleaned_data
-                    # save all sections ONLY is all valid!
                     section_info = SectionInfo(s, dyn_patient, False, registry_code, "cdes", dynamic_data,form_class=form_class)
                     sections_to_save.append(section_info)
                     current_data = dyn_patient.load_dynamic_data(self.registry.code, "cdes")
                     form_data = wrap_file_cdes(registry_code, dynamic_data, current_data, multisection=False)
                     form_section[s] = form_class(dynamic_data, initial=form_data)
                 else:
-                    logger.debug("form is invalid")
                     all_sections_valid = False
                     for e in form.errors:
                         error_count += 1
@@ -476,7 +455,6 @@ class FormView(View):
                     form_section[s] = form_class(wrap_uploaded_files(registry_code, request.POST), request.FILES)
 
             else:
-                logger.debug("handling POST of multisection %s" % section_model)
                 if section_model.extra:
                     extra = section_model.extra
                 else:
@@ -491,26 +469,14 @@ class FormView(View):
                 assert formset.prefix == prefix
 
                 if formset.is_valid():
-
-                    logger.debug("multisection formset is valid")
                     dynamic_data = formset.cleaned_data  # a list of values
-                    logger.debug("formset data = %s" % dynamic_data)
                     to_remove = [i for i, d in enumerate(dynamic_data) if d.get('DELETE')]
                     index_map = make_index_map(to_remove, len(dynamic_data))
-                    logger.debug("to_remove = %s" % to_remove)
-                    logger.debug("index_map = %s" % index_map)
 
                     for i in reversed(to_remove):
-                        logger.debug("DELETEing %s" % i)
-                        clobbered = dynamic_data[i]
-                        logger.debug("This is the item that gets clobbered for i = %s : %s" % (i, clobbered))
-                        
                         del dynamic_data[i]
 
-                    logger.debug("data after deletion = %s" % dynamic_data)
                     current_data = dyn_patient.load_dynamic_data(self.registry.code, "cdes")
-                    logger.debug("current_data = %s" % current_data)
-
                     section_dict = {s: dynamic_data}
                     section_info = SectionInfo(s,
                                                dyn_patient,
@@ -523,29 +489,11 @@ class FormView(View):
                                                prefix=prefix)
 
                     sections_to_save.append(section_info)
-
-
                     form_data = wrap_file_cdes(registry_code, dynamic_data, current_data, multisection=True, index_map=index_map)
-                    logger.debug("form_data on the form for section %s  = %s" % (s, form_data)) 
-                    try:
-                        for x in form_data:
-                            for k in x:
-                                try:
-                                    logger.debug("form data %s = %s" % (k, x))
-                                    if type(x) is dict:
-                                        for k2 in x:
-                                            logger.debug("%s = %s" % (k2, x[k2]))
-                                            
-                                except Exception as ex:
-                                    logger.debug("err: %s" % ex)
-                    except Exception as ex2:
-                        logger.debug("err2: %s" % ex2)
-
                     form_section[s] = form_set_class(initial=form_data, prefix=prefix)
 
                 else:
                     all_sections_valid = False
-                    logger.debug("multisection formset is invalid")
                     for e in formset.errors:
                         error_count += 1
                         all_errors.append(e)
@@ -578,16 +526,10 @@ class FormView(View):
 
             if dyn_patient.rdrf_context_id == "add":
                 raise Exception("Content not created")
-        else:
-            for e in all_errors:
-                logger.debug("validation Error: %s" % e)
 
         patient_name = '%s %s' % (patient.given_names, patient.family_name)
         # progress saved to progress collection in mongo
         # the data is returned also
-
-        logger.debug("rdrf context = %s" % self.rdrf_context)
-
         wizard = NavigationWizard(self.user,
                                   registry,
                                   patient,
@@ -924,7 +866,6 @@ class ConsentFormWrapper(object):
         messages = []
         for field in self.form.errors:
             for message in self.form.errors[field]:
-                logger.debug("consent error for %s: %s" % (self.label, message))
                 messages.append(_("Consent Section Invalid"))
 
         return messages
@@ -997,7 +938,6 @@ class QuestionnaireView(FormView):
             prelude_file = "prelude_%s_%s.html" % (registry_code, questionnaire_context)
 
         file_path = os.path.join(settings.TEMPLATES[0]["DIRS"][0], 'rdrf_cdes', prelude_file)
-        logger.debug("file path = %s" % file_path)
         if os.path.exists(file_path):
             return os.path.join('rdrf_cdes', prelude_file)
         else:
@@ -1038,8 +978,6 @@ class QuestionnaireView(FormView):
 
         error_count += custom_consent_helper.error_count
 
-        logger.debug("Error count after checking custom consents = %s" % error_count)
-
         self.questionnaire_context = self._get_questionnaire_context(request)
 
         questionnaire_form = registry.questionnaire
@@ -1058,7 +996,6 @@ class QuestionnaireView(FormView):
         section_field_ids_map = {}
 
         for section in sections:
-            logger.debug("processing section %s" % section)
             section_model = Section.objects.get(code=section)
             section_elements = section_model.get_elements()
             section_element_map[section] = section_elements
@@ -1073,13 +1010,10 @@ class QuestionnaireView(FormView):
                 form = form_class(request.POST, request.FILES)
                 form_section[section] = form
                 if form.is_valid():
-                    logger.debug("section %s is valid" % section_model.display_name)
                     dynamic_data = form.cleaned_data
                     data_map[section] = dynamic_data
                 else:
-                    logger.debug("section %s is NOT valid" % section_model.display_name)
                     for e in form.errors:
-                        logger.debug("Error in %s: %s" % (section_model.display_name, e))
                         error_count += 1
             else:
                 if section_model.extra:
@@ -1097,20 +1031,15 @@ class QuestionnaireView(FormView):
                 formset = form_set_class(request.POST, prefix=prefix)
 
                 if formset.is_valid():
-                    logger.debug("section %s is valid" % section_model.display_name)
                     dynamic_data = formset.cleaned_data  # a list of values
                     section_dict = {}
                     section_dict[section] = dynamic_data
                     data_map[section] = section_dict
                 else:
-                    logger.debug("section %s is NOT valid" % section_model.display_name)
                     for e in formset.errors:
-                        logger.debug("Error in %s: %s" % (section_model.display_name, e))
                         error_count += 1
 
         if error_count == 0:
-            logger.debug("All forms are valid")
-
             questionnaire_response = QuestionnaireResponse()
             questionnaire_response.registry = registry
             questionnaire_response.save()
@@ -1155,7 +1084,6 @@ class QuestionnaireView(FormView):
                             field_key = consent_question_model.field_key
                             try:
                                 value = custom_consent_data[field_key]
-                                logger.debug("%s = %s" % (field_key, value))
                                 if value == "on":
                                     question_wrapper.answer = "Yes"
                             except KeyError:
@@ -1265,8 +1193,6 @@ class QuestionnaireView(FormView):
 
             return render(request, 'rdrf_cdes/completed_questionnaire_thankyou.html', context)
         else:
-            logger.debug("Error count non-zero!:  %s" % error_count)
-
             context = {
                 'custom_consent_wrappers': custom_consent_helper.custom_consent_wrappers,
                 'custom_consent_errors': custom_consent_helper.custom_consent_errors,
@@ -1992,7 +1918,6 @@ class AdjudicationResultsView(View):
         actions = []
         for adjudication_cde_model in definition.action_cde_models:
             for k in post_data:
-                logger.debug(k)
                 if adjudication_cde_model.code in k:
                     value = post_data[k]
                     actions.append((adjudication_cde_model.code, value))
@@ -2013,7 +1938,6 @@ class CustomConsentFormView(View):
             login_url = reverse('login')
             return redirect("%s?next=%s" % (login_url, consent_form_url))
 
-        logger.debug("******************** loading consent form *********************")
         patient_model = Patient.objects.get(pk=patient_id)
         registry_model = Registry.objects.get(code=registry_code)
         form_sections = self._get_form_sections(registry_model, patient_model)
@@ -2054,9 +1978,6 @@ class CustomConsentFormView(View):
             "show_print_button": True,
         }
 
-        logger.debug("context = %s" % context)
-
-        logger.debug("******************** rendering get *********************")
         return render(request, "rdrf_cdes/custom_consent_form.html", context)
 
     def _get_initial_consent_data(self, patient_model):
@@ -2067,8 +1988,6 @@ class CustomConsentFormView(View):
         data = patient_model.consent_questions_data
         for consent_field_key in data:
             initial_data[consent_field_key] = data[consent_field_key]
-            logger.debug("set initial consent data for %s to %s" %
-                         (consent_field_key, data[consent_field_key]))
         return initial_data
 
     def _get_form_sections(self, registry_model, patient_model):
@@ -2127,7 +2046,6 @@ class CustomConsentFormView(View):
                                                   patient_model.pk])
 
     def post(self, request, registry_code, patient_id, context_id=None):
-        logger.debug("******************** post of consents *********************")
         if not request.user.is_authenticated():
             consent_form_url = reverse('consent_form_view', args=[registry_code, patient_id, context_id])
             login_url = reverse('login')
@@ -2150,8 +2068,6 @@ class CustomConsentFormView(View):
         patient_consent_file_formset = inlineformset_factory(Patient, PatientConsent,
                                                              form=PatientConsentFileForm,
                                                              fields="__all__")
-
-        logger.debug("patient consent file formset = %s" % patient_consent_file_formset)
 
         patient_consent_file_forms = patient_consent_file_formset(request.POST,
                                                                   request.FILES,
@@ -2211,19 +2127,12 @@ class CustomConsentFormView(View):
         }
 
         if all(valid_forms):
-            logger.debug("******************** forms valid :)  *********************")
-            logger.debug("******************** saving any consent files *********************")
             things = patient_consent_file_forms.save()
             patient_consent_file_forms.initial = things
-            logger.debug("***** ||| things = %s" % things)
-            logger.debug("******************** end of consent file save *********************")
-            logger.debug("******************** saving custom consent form *********************")
             custom_consent_form.save()
-            logger.debug("******************** end of consent save *********************")
             context["message"] = "Patient %s %s saved successfully" % (patient_model.given_names,
                                                                        patient_model.family_name)
         else:
-            logger.debug("******************** forms invalid :( *********************")
             context["message"] = "Some forms invalid"
             context["error_messages"] = error_messages
             context["errors"] = True


### PR DESCRIPTION
Items ( blocks of CDEs) in a multisection can be "marked for deletion" and then the form saved, causing the entire block of cdes ( form in a formset)  to be deleted - this has the effect of changing the indices of the items. In order to correctly display file links for file cdes on cdes which have not been uploaded in the POST ( but have in earlier POSTS) - values of the uploaded file django ids for the cde need to be retrieved but IF items have been marked for deletion ( and deleted in the current POST) the cde values from the correct index needs to be loaded prior to the record being saved

An "index map" of new indices to old indices after a deletion was introduced to enable this , but it wasn't being correctly threaded some of the refactored code for the file storage code resulting in the wrong item's data being presented in the view.

I've added an aloe test to upload files in 2 multisection items and then perform a delete of the first item.

The test checks that the second upload file is available but the first isn't.
 

