### PR TITLE
Consent View fixes

### DIFF
--- a/rdrf/rdrf/form_view.py
+++ b/rdrf/rdrf/form_view.py
@@ -2132,6 +2132,8 @@ class CustomConsentFormView(View):
             custom_consent_form.save()
             context["message"] = "Patient %s %s saved successfully" % (patient_model.given_names,
                                                                        patient_model.family_name)
+            messages.success(self.request, context["message"])
+            return HttpResponseRedirect(self._get_success_url(registry_model, patient_model))
         else:
             context["message"] = "Some forms invalid"
             context["error_messages"] = error_messages

--- a/rdrf/rdrf/form_view.py
+++ b/rdrf/rdrf/form_view.py
@@ -2107,36 +2107,35 @@ class CustomConsentFormView(View):
         except ParentGuardian.DoesNotExist:
             parent = None
 
-        context = {
-            "location": "Consents",
-            "patient": patient_model,
-            "patient_id": patient_model.id,
-            'patient_link': PatientLocator(registry_model, patient_model).link,
-            "context_id": context_id,
-            "registry_code": registry_code,
-            "show_archive_button": request.user.can_archive,
-            "not_linked": not patient_model.is_linked,
-            "archive_patient_url": patient_model.get_archive_url(registry_model) if request.user.can_archive else "",
-            "next_form_link": wizard.next_link,
-            "previous_form_link": wizard.previous_link,
-            "context_launcher": context_launcher.html,
-            "forms": form_sections,
-            "error_messages": [],
-            "parent": parent,
-            "consent": consent_status_for_patient(registry_code, patient_model)
-        }
-
         if all(valid_forms):
             things = patient_consent_file_forms.save()
             patient_consent_file_forms.initial = things
             custom_consent_form.save()
-            context["message"] = "Patient %s %s saved successfully" % (patient_model.given_names,
-                                                                       patient_model.family_name)
-            messages.success(self.request, context["message"])
+            messages.success(self.request, "Patient %s %s saved successfully" % (patient_model.given_names,
+                                                                                 patient_model.family_name))
             return HttpResponseRedirect(self._get_success_url(registry_model, patient_model))
         else:
+            context = {
+                "location": "Consents",
+                "patient": patient_model,
+                "patient_id": patient_model.id,
+                'patient_link': PatientLocator(registry_model, patient_model).link,
+                "context_id": context_id,
+                "registry_code": registry_code,
+                "show_archive_button": request.user.can_archive,
+                "not_linked": not patient_model.is_linked,
+                "archive_patient_url": patient_model.get_archive_url(registry_model) if request.user.can_archive else "",
+                "next_form_link": wizard.next_link,
+                "previous_form_link": wizard.previous_link,
+                "context_launcher": context_launcher.html,
+                "forms": form_sections,
+                "error_messages": [],
+                "parent": parent,
+                "consent": consent_status_for_patient(registry_code, patient_model)
+            }
+
             context["message"] = "Some forms invalid"
             context["error_messages"] = error_messages
             context["errors"] = True
 
-        return render(request, "rdrf_cdes/custom_consent_form.html", context)
+            return render(request, "rdrf_cdes/custom_consent_form.html", context)

--- a/rdrf/rdrf/form_view.py
+++ b/rdrf/rdrf/form_view.py
@@ -2102,19 +2102,19 @@ class CustomConsentFormView(View):
             else:
                 valid_forms.append(True)
 
-        try:
-            parent = ParentGuardian.objects.get(user=request.user)
-        except ParentGuardian.DoesNotExist:
-            parent = None
-
+       
         if all(valid_forms):
-            things = patient_consent_file_forms.save()
-            patient_consent_file_forms.initial = things
+            patient_consent_file_forms.save()
             custom_consent_form.save()
             messages.success(self.request, "Patient %s %s saved successfully" % (patient_model.given_names,
                                                                                  patient_model.family_name))
             return HttpResponseRedirect(self._get_success_url(registry_model, patient_model))
         else:
+            try:
+                parent = ParentGuardian.objects.get(user=request.user)
+            except ParentGuardian.DoesNotExist:
+                parent = None
+
             context = {
                 "location": "Consents",
                 "patient": patient_model,


### PR DESCRIPTION
We'd  removed a redirect to fix another issue ( success message not appearing.)

I put back the redirect and created the success message in the correct way.
I have refactored slightly to make clearer ( no context dictionary needs to be created if the form is valid)