### PR TITLE
Fh multisectionimport

### DIFF
--- a/rdrf/rdrf/generalised_field_expressions.py
+++ b/rdrf/rdrf/generalised_field_expressions.py
@@ -95,20 +95,12 @@ class MultiSectionItemsExpression(GeneralisedFieldExpression):
 
     def set_value(self, patient_model, mongo_data, replacement_items, **kwargs):
         # mongo data must be _nested_
-        items = []
-        for cde_map in replacement_items:
-            cde_dict_list = []
-            for cde_code in cde_map:
-                cde_dict = {"code": cde_code,
-                            "value": cde_map[cde_code]}
-                cde_dict_list.append(cde_dict)
-            items.append(cde_dict_list)
-
+    
         if mongo_data is None:
             mongo_data = {"forms": [{"name": self.form_model.name,
                                      "sections": [{"code": self.section_model.code,
                                                    "allow_multiple": True,
-                                                   "cdes": items}]}]}
+                                                   "cdes": replacement_items}]}]}
             return patient_model, mongo_data
 
         else:
@@ -121,19 +113,19 @@ class MultiSectionItemsExpression(GeneralisedFieldExpression):
                     for section_dict in form_dict["sections"]:
                         if section_dict["code"] == self.section_model.code:
                             section_exists = True
-                            section_dict["cdes"] = items
+                            section_dict["cdes"] = replacement_items
                             return patient_model, mongo_data
                     if not section_exists:
                         section_dict = {"code": self.section_model.code,
                                         "allow_multiple": True,
-                                        "cdes": items}
+                                        "cdes": replacement_items}
                         form_dict["sections"].append(section_dict)
                         return patient_model, mongo_data
             if not form_exists:
                 form_dict = {"name": self.form_model.name,
                              "sections": [{"code": self.section_model.code,
                                            "allow_multiple": True,
-                                           "cdes": items}]
+                                           "cdes": replacement_items}]
                              }
                 mongo_data["forms"].append(form_dict)
                 return patient_model, mongo_data

--- a/scripts/import_multisection_data.py
+++ b/scripts/import_multisection_data.py
@@ -140,6 +140,8 @@ for patient_data in reader:
     else:
         try:
             patient_model = Patient.objects.get(pk=rdrf_id)
+            info("Found patient %s" % patient_model)
+            
             if existing_data(patient_model):
                 error("Existing data for %s/%s" % (patient_data.old_id,
                                                    rdrf_id))
@@ -149,13 +151,17 @@ for patient_data in reader:
                                                 rdrf_id))
 
             info("items = %s" % patient_data.items)
+
+
+            try:
+                patient_model.evaluate_field_expression(fh_registry,
+                                                        field_expression,
+                                                        value=patient_data.items)
+                
+                info("Updated patient %s/%s OK" % (patient_data.old_id, rdrf_id))
+            except Exception as ex:
+                error("Updated failed: %s" % ex)
             
-            patient_model.evaluate_field_expression(fh_registry,
-                                                    field_expression,
-                                                    value=patient_data.items)
-            
-            info("Updated patient %s/%s" % (patient_data.old_id,
-                                            rdrf_id))
             
         except Patient.DoesNotExist:
             error("No patient with id %s" % rdrf_id)

--- a/scripts/import_multisection_data.py
+++ b/scripts/import_multisection_data.py
@@ -129,13 +129,13 @@ reader.read()
 idmap = build_idmap(idmap_file)
 
 # we're updating just one multisection
-field_expression = "$op/%s/%s/items" % (Codes.FORM,
+field_expression = "$ms/%s/%s/items" % (Codes.FORM,
                                         Codes.MULTISECTION)
 
 for patient_data in reader:
     rdrf_id = idmap.get(patient_data.old_id, None)
     if rdrf_id is None:
-        error("Patient %s does not exist in mapping file" % patient_data.old_id)
+        #error("Patient %s does not exist in mapping file" % patient_data.old_id)
         continue
     else:
         try:
@@ -147,6 +147,8 @@ for patient_data in reader:
 
             info("Updating patient %s/%s .." % (patient_data.old_id,
                                                 rdrf_id))
+
+            info("items = %s" % patient_data.items)
             
             patient_model.evaluate_field_expression(fh_registry,
                                                     field_expression,

--- a/scripts/import_multisection_data.py
+++ b/scripts/import_multisection_data.py
@@ -1,0 +1,121 @@
+import django
+django.setup()
+
+import sys
+from operator import itemgetter
+from rdrf.models import Registry
+from registry.patients.models import Patient
+
+class Codes:
+    FORM = ""
+    MULTISECTION = "hh"
+    GENEVARIANT = "aa"
+    DESCRIPTION = "bb"
+    PATHOGENICITY = "aaa"
+
+class PatientData:
+    def __init__(self, patient_id, items):
+        self.old_id = patient_id
+        self.items = items
+
+class Reader:
+    def __init__(self, csv_file):
+        self.csv_file = csv_file
+        self.patient_data = []
+        
+    def read(self):
+        import csv
+        patient_map = {}
+        with open(self.csv_file) as f:
+            csvreader = csv.DictReader(f)
+            for row in csvreader:
+                if row["PatientID"] in patient_map:
+                    patient_map[row["PatientID"]].append(row)
+                else:
+                    patient_map[row["PatientID"]] = [row]
+        for patient_id in patient_map:
+            items = self._make_items(patient_id, patient_map[patient_id])
+            self.patient_data.append(PatientData(patient_id, items))
+
+
+    def _make_items(self, patient_id, rows):
+        items = []
+        for row in sorted(rows,key=itemgetter('SectionIndex')):
+            cde_dicts = []
+            cde_dicts.append(self._make_cde_dict(code=Codes.GENEVARIANT,
+                                                 value=row["GeneVariant"]))
+
+            cde_dicts.append(self._make_cde_dict(code=Codes.DESCRIPTION,
+                                                 value=row["Description"]))
+
+            cde_dicts.append(self._make_cde_dict(code=Codes.PATHOGENICITY,
+                                                 value=row["Pathogenicity"]))
+
+            items.append(cde_dicts)
+
+        return items
+
+    def _make_cde_dict(self, code, value):
+        return {"code": code,
+                "value": value}
+    
+    def __iter__(self):
+        for data in self.patient_data:
+            yield data
+           
+def buildid_map(mapfile):
+    idmap = {}
+    with open(mapfile) as mf:
+        for line in mf.readlines():
+            old_id, new_id = line.strip().split(",")
+            idmap[old_id] = new_id
+    return idmap
+
+def error(msg):
+    print("Error: %s" % msg)
+
+def info(msg):
+    print("Info: %s" % msg)
+
+def existing_data(patient_model):
+    return False 
+    
+    
+idmap_file = sys.argv[1]
+spreadsheet_file = sys.argv[2]
+
+fh_registry = Registry.objects.get(code="fh")
+
+reader = SpreadSheetReader(spreadsheet_file)
+reader.read()
+
+idmap = build_idmap(idmap_file)
+
+# we're updating just one multisection
+field_expression = "$op/%s/%s/items" % (Codes.FORM,
+                                        Codes.MULTISECTION)
+
+for patient_data in reader:
+    rdrf_id = idmap.get(patient_data.old_id, None)
+    if rdrf_id is None:
+        error("Patient %s does not exist in mapping file" % patient_data.old_id)
+    else:
+        try:
+            patient_model = Patient.objects.get(pk=rdrf_id)
+            if existing_data(patient_model):
+                error("Existing data for %s/%s" % (patient_data.old_id,
+                                                   rdrf_id))
+                continue
+
+            patient_model.evaluate_field_expression(fh_registry,
+                                                    field_expression,
+                                                    value=patient_data.items)
+            
+            info("Updated patient %s/%s" % (patient_data.old_id,
+                                            rdrf_id))
+            
+        except Patient.DoesNotExist:
+            error("No patient with id %s" % rdrf_id)
+        
+            
+

--- a/scripts/import_multisection_data.py
+++ b/scripts/import_multisection_data.py
@@ -7,8 +7,6 @@ from rdrf.models import Registry
 from rdrf.models import CommonDataElement
 from rdrf.models import CDEPermittedValue
 
-
-
 from registry.patients.models import Patient
 
 class MissingCodeError(Exception):
@@ -51,14 +49,17 @@ class Reader:
         items = []
         for row in sorted(rows,key=itemgetter('SectionIndex')):
             cde_dicts = []
-            cde_dicts.append(self._make_cde_dict(Codes.GENEVARIANT,
-                                                 row["GeneVariant"]))
+            if row["GeneVariant"]:
+                cde_dicts.append(self._make_cde_dict(Codes.GENEVARIANT,
+                                                     row["GeneVariant"]))
 
-            cde_dicts.append(self._make_cde_dict(Codes.DESCRIPTION,
-                                                 row["Description"]))
+            if row["Description"]:
+                cde_dicts.append(self._make_cde_dict(Codes.DESCRIPTION,
+                                                     row["Description"]))
 
-            cde_dicts.append(self._make_cde_dict(Codes.PATHOGENICITY,
-                                                 row["Pathogenicity"]))
+            if row["Pathogenicity"]:
+                cde_dicts.append(self._make_cde_dict(Codes.PATHOGENICITY,
+                                                     row["Pathogenicity"]))
 
             items.append(cde_dicts)
 


### PR DESCRIPTION
Added import_multisection_data.py script 


usage:


python /app/scripts/import_multisection_data.py mapfile csvdatafile  > logfile


The mapfile looks like:

old id1,rdrf id1
old id2,rdrf id2
old id3>,rdrf id3

and is a by product of the original fh data import

csv data file was created by exporting from the returned spreadsheet Jing provided ( we gave them a format.)

All the script does is update multi-section data in the genetic data form. No attempt to generalise it has been made but we could adapt very easily to create a generic importer as the script merely calls into an existing "field expression" parser which was previously written  for reports (get) and questionnaire updating (set.)





