### PR TITLE
Fixes to questionnaire multisection behaviour

### DIFF
--- a/rdrf/rdrf/form_view.py
+++ b/rdrf/rdrf/form_view.py
@@ -192,6 +192,7 @@ class FormView(View):
         self.patient_id = None
         self.user = None
         self.rdrf_context = None
+        self.show_multisection_delete_checkbox = True
 
         super(FormView, self).__init__(*args, **kwargs)
 
@@ -706,7 +707,7 @@ class FormView(View):
                     extra = section_model.extra
                 else:
                     extra = 0
-                form_set_class = formset_factory(form_class, extra=extra, can_delete=True)
+                form_set_class = formset_factory(form_class, extra=extra, can_delete=self.show_multisection_delete_checkbox)
                 if self.dynamic_data:
                     try:
                         # we grab the list of data items by section code not cde code
@@ -894,6 +895,7 @@ class QuestionnaireView(FormView):
         self.questionnaire_context = None
         self.template = 'rdrf_cdes/questionnaire.html'
         self.CREATE_MODE = False
+        self.show_multisection_delete_checkbox = False
 
     @method_decorator(patient_questionnaire_access)
     def get(self, request, registry_code, questionnaire_context="au"):

--- a/rdrf/rdrf/questionnaires.py
+++ b/rdrf/rdrf/questionnaires.py
@@ -299,8 +299,9 @@ class QuestionnaireReverseMapper(object):
                     k)
                 original_form_name, original_section_code = self.parse_generated_section_code(
                     generated_section_code)
-
-                yield self.registry.code, original_form_name, original_section_code, cde_code, self.questionnaire_data[k]
+                reg_code = self.registry_code
+                q_data = self.questionnaire_data[k]
+                yield reg_code, original_form_name, original_section_code, cde_code, q_data
 
             if not dynamic and not is_a_dynamic_field:
                 logger.debug("yield non-dynamic %s" % k)
@@ -604,15 +605,6 @@ class _ExistingDataWrapper(object):
         return l
 
     def _get_consent_answer(self, consent_question):
-        #
-        # NB consent answer stored in mongo ..
-        # class ConsentValue(models.Model):
-        #patient = models.ForeignKey(Patient, related_name="consents")
-        #consent_question = models.ForeignKey(ConsentQuestion)
-        #answer = models.BooleanField(default=False)
-        #first_save = models.DateField(null=True, blank=True)
-        #last_update = models.DateField(null=True, blank=True)
-
         from registry.patients.models import ConsentValue
         try:
             consent_value_model = ConsentValue.objects.get(patient=self.patient_model,
@@ -625,13 +617,6 @@ class _ExistingDataWrapper(object):
         return "No"
 
     def _get_address_labels(self, addresses_expression):
-        #patient = models.ForeignKey(Patient)
-        #address_type = models.ForeignKey(AddressType, default=1)
-        #address = models.TextField()
-        #suburb = models.CharField(max_length=100, verbose_name="Suburb/Town")
-        #state = models.CharField(max_length=50, verbose_name="State/Province/Territory")
-        #postcode = models.CharField(max_length=50)
-        #country = models.CharField(max_length=100)
 
         def address_label(address):
             try:
@@ -684,15 +669,16 @@ class _ExistingDataWrapper(object):
 
 class _ConsentQuestion(object):
         # Mongo record looks like this on questionnaire:
-        #                                                                        question
-        #"customconsent_%s_%s_%s" % (registry_model.pk, consent_section_model.pk, self.pk)
-        #"custom_consent_data" : {
-                #"customconsent_2_2_3" : "on",
-                #"customconsent_2_2_6" : "on",
-                #"customconsent_2_2_5" : "on",
-                #"customconsent_2_2_4" : "on",
-                #"customconsent_2_1_1" : "on",
-                #"customconsent_2_1_2" : "on"
+        # question
+        # "customconsent_%s_%s_%s" %
+        # (registry_model.pk, consent_section_model.pk, self.pk)
+        # "custom_consent_data" : {
+        # "customconsent_2_2_3" : "on",
+        # "customconsent_2_2_6" : "on",
+        # "customconsent_2_2_5" : "on",
+        # "customconsent_2_2_4" : "on",
+        # "customconsent_2_1_1" : "on",
+        # "customconsent_2_1_2" : "on"
 
     def __init__(self, registry_model, key, raw_value):
         self.is_multi = False
@@ -829,8 +815,11 @@ class _Question(object):
             return self.humaniser.display_value2(self.form_model, self.section_model, self.cde_model, value)
         else:
             if not self.is_address:
-                return ",".join([self.humaniser.display_value2(self.form_model, self.section_model,
-                                                               self.cde_model, single_value) for single_value in value])
+                display = self.humaniser.display_value2
+                return ",".join([display(self.form_model,
+                                         self.section_model,
+                                         self.cde_model,
+                                         single_value) for single_value in value])
             else:
                 return ",".join([x for x in value])
 
@@ -1111,17 +1100,18 @@ class Questionnaire(object):
         return new_ordering
 
     def _get_consents(self):
-        # Mongo record looks like in questionnaire - ( NB not in Patients ...):
+        # Clinical record looks like in questionnaire - ( NB not in Patients ...):
         # for patients , the consent data stored in django models
-        #                                                                        question
-        #"customconsent_%s_%s_%s" % (registry_model.pk, consent_section_model.pk, self.pk)
-        #"custom_consent_data" : {
-                #"customconsent_2_2_3" : "on",
-                #"customconsent_2_2_6" : "on",
-                #"customconsent_2_2_5" : "on",
-                #"customconsent_2_2_4" : "on",
-                #"customconsent_2_1_1" : "on",
-                #"customconsent_2_1_2" : "on"
+        # question
+        # "customconsent_%s_%s_%s" % (registry_model.pk, consent_section_model.pk, self.pk)
+        # "custom_consent_data" : {
+        # "customconsent_2_2_3" : "on",
+        # "customconsent_2_2_6" : "on",
+        # "customconsent_2_2_5" : "on",
+        # "customconsent_2_2_4" : "on",
+        # "customconsent_2_1_1" : "on",
+        # "customconsent_2_1_2" : "on"
+
         consents = []
 
         if CONSENTS_SECTION in self.data:
@@ -1172,17 +1162,14 @@ class Questionnaire(object):
             # a list of (ordered) dictionaries like:
             # [ {"DrugName": "Aspirin", "DrugDose": 23},
             #   {"DrugName": "Neurophen","DrugDose": 100}]
-            #   
             # ( i.e. 2 section items in the multisection )
-
             # The structure actually used in the clinical forms is:
             # in the multisection record would be:
             # cdes: [  [ {"code": "DrugName", "value": "Aspirin"}, {"code": "DrugDose",
             # "value" : 23 } ],  [ {"code" "DrugName", "value": "Neurophen"},
             # {"code": "DrugDose", "value": 100}]]
-            
+
             items = []
-            
             for ordered_dict in ordered_dicts:
                 item = []
                 for cde_code, cde_value in ordered_dict.items():
@@ -1191,23 +1178,16 @@ class Questionnaire(object):
                     cde_dict["value"] = cde_value
                     item.append(cde_dict)
                 items.append(item)
-                    
-                
             return items
 
         for q in multisection_questions:
             logger.debug("about to evaluate field expression %s" %
                          q.field_expression)
             try:
-                logger.debug("Updating multisection from questionnaire!")
                 if not q.field_expression.startswith("Demographics/"):
-                    # clinical multisection structure is in incorrect format
                     items = correct_structure(q.value)
                 else:
                     items = q.value
-                logger.debug("field_expression = %s" % q.field_expression)
-                logger.debug("items list = %s" % items)
-                
                 patient_model.evaluate_field_expression(self.registry_model,
                                                         q.field_expression,
                                                         value=items)

--- a/rdrf/rdrf/questionnaires.py
+++ b/rdrf/rdrf/questionnaires.py
@@ -9,7 +9,6 @@ from registry.patients.models import PatientAddress, AddressType
 from .dynamic_data import DynamicDataWrapper
 from django.conf import settings
 from registry.groups.models import WorkingGroup
-from django.db import transaction
 from datetime import date
 from datetime import datetime
 import pycountry
@@ -1147,7 +1146,6 @@ class Questionnaire(object):
                                     )
 
     def update_patient(self, patient_model, selected_questions):
-        # begin transaction ... etc
         # NB. here that the _original_ target form needs to be updated ( the source of the question )
         # NOT the dynamically generated questionnaire form's version ...
         errors = []

--- a/rdrf/rdrf/templates/rdrf_cdes/questionnaire.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/questionnaire.html
@@ -7,6 +7,7 @@
 {% load lookup %}
 {% load get_forms %}
 {% load get_form_var %}
+{% load get_form_object %}
 {% load widget_name %}
 {% load add_attr %}
 {% load static %}
@@ -79,6 +80,58 @@
                 });
             }
         }
+
+
+        function add_form(prefix) {
+            var mgmt_form = $("#mgmt_" + prefix);
+            var empty_form = $("#empty_" + prefix);
+            var forms = $("#forms_" + prefix);
+
+            var total_forms = mgmt_form.find("input[id=id_"+ prefix +"-TOTAL_FORMS]")
+            var initial_forms = mgmt_form.find("input[id=id_"+ prefix +"-INITIAL_FORMS]")
+            
+            var new_form = empty_form.clone(true, true);
+            
+            new_form.find(":input").each(function() {
+		$(this).attr("id", $(this).attr("id").replace(/__prefix__/g, total_forms.val()));
+		$(this).attr("name", $(this).attr("name").replace(/__prefix__/g, total_forms.val()));
+		
+		if ($(this).hasClass("datepicker")) {
+                    $(this).datepicker({
+			changeMonth: true,
+			changeYear: true,
+			dateFormat: 'dd-mm-yy',
+			yearRange: '-100:+0',
+			buttonImage: "/static/images/calendar.gif",
+			buttonImageOnly: true,
+                    });
+		}
+            });
+
+            var total_forms_inc = parseInt(total_forms.val()) + 1;
+	    console.log("There are now " + total_forms_inc.toString() + " forms for " + prefix);
+            total_forms.attr("value", total_forms_inc);
+            //initial_forms.attr("value", total_forms_inc);
+            initial_forms.attr("value", 0);
+
+            $("<hr>").attr("style", "border: solid 1px gray").appendTo(new_form);
+
+	    //new_form.appendTo(forms).show("fast");
+	    new_form.appendTo(forms).show("fast");
+    }
+
+    function delete_form(form_div, prefix) {
+        var mgmt_form = $("#mgmt_" + prefix);
+        var total_forms = mgmt_form.find("input[id=id_"+ prefix +"-TOTAL_FORMS]")
+        var initial_forms = mgmt_form.find("input[id=id_"+ prefix +"-INITIAL_FORMS]")
+        var total_forms_dec = parseInt(total_forms.val()) - 1;
+        total_forms.attr("value", total_forms_dec);
+        //initial_forms.attr("value", total_forms_dec);
+        initial_forms.attr("value", 0);
+
+        $(form_div).parent().parent().parent().remove();
+    }
+
     </script>
 {% endblock %}
 
@@ -140,34 +193,39 @@
 
                 <div class="panel-body">
                     {% if forms|is_formset:s %}
+		    
                         <!-- start management form for {{s}}-->
-                        {{ forms|get_management_form:s }}
+			{% with formset=forms|get_form_object:s %}
+			<div id="mgmt_{{formset.prefix}}">
+			  {{formset.management_form}}
+			</div>
                         <!-- end management form for {{s}} -->
-                        <button id="add_button_for_section_{{s}}" type="button" class="btn btn-success btn-small"><i class="icon-white icon-plus"></i> {% trans 'Add' %}</button>
-                        <table class="table" id="section_table_{{s}}">
-                            <script>
-                                $(document).ready(function() {
-                                    $("#section_table_{{s}}").allow_dynamic_formsets({
-                                        cde_codes: '{{section_field_ids_map|lookup:s}}',
-                                        add_button_id: "add_button_for_section_{{s}}",
-                                        remove_button_id: "remove_button_for_section_{{s}}",
-                                        table_id: "section_table_{{s}}",
-                                        total_forms_id: "{{total_forms_ids|lookup:s}}",
-                                        initial_forms_id: "{{initial_forms_ids|lookup:s}}",
-                                        formset_prefix: "{{formset_prefixes|lookup:s}}"
-                                    });
-                                });
-                            </script>
+			
+			<!-- start of hidden empty form for {{s}} -->
+			<div style="display: none;" id="empty_{{formset.prefix}}">
+			  {{formset.empty_form.as_table}}
+                           <div class="form-group">
+                                        <div class="col-sm-9 col-sm-offset-3">
+                                            <a class="btn btn-danger btn-xs pull-right" onclick="delete_form(this, '{{formset.prefix}}')">
+                                                <span class="glyphicon glyphicon-minus" aria-hidden="true"></span> {% trans "Remove" %}
+                                            </a>
+                                        </div>
+                                    </div>
+
+			</div>
+			<!-- end of hidden empty form for {{s}} -->
+
+                        <button id="add_button_for_section_{{s}}" type="button" class="btn btn-success btn-small" onclick="add_form('{{formset.prefix}}');"><i class="icon-white icon-plus"></i> {% trans 'Add' %}</button>
+			<div id="forms_{{formset.prefix}}">
+
                             {% for f in forms|get_forms:s %}
-                                {{ f.as_table }}
-                                <tr id="remove_formset_{{s}}_{{forloop.counter0}}" class="actionbutton">
-                                    <td onclick="do_remove(this,'section_table_{{s}}',{{section_element_map|lookup:s|length}},'id_formset_{{s}}-TOTAL_FORMS','id_formset_{{s}}-INITIAL_FORMS');"><button type="button" class="btn btn-danger btn-small">
-                                        <i class="icon-white icon-minus"></i> {% trans 'Remove' %}
-                                    </button>
-                                    </td>
-                                </tr>
+                                <div>
+                                   {{ f }}
+                                </div>
                             {% endfor %}
-                        </table>
+			   
+			</div>
+			{% endwith %}
                     {% else %}
                         <table class="table table-bordered table-hover table-condensed">
                             {% autoescape off %}

--- a/rdrf/rdrf/templates/rdrf_cdes/questionnaire.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/questionnaire.html
@@ -113,6 +113,10 @@
 
             $("<hr>").attr("style", "border: solid 1px gray").appendTo(new_form);
 
+	    if(total_forms_inc == 2) {
+		$("<hr>").attr("style", "border: solid 1px gray").prependTo(new_form);
+	    }
+
 	    var nodes = $(new_form).children().detach();
 	    var new_item = $("<div class='item'>").append(nodes);
 	    new_item.appendTo(forms).show("fast");

--- a/rdrf/rdrf/templates/rdrf_cdes/questionnaire.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/questionnaire.html
@@ -109,15 +109,13 @@
             });
 
             var total_forms_inc = parseInt(total_forms.val()) + 1;
-	    console.log("There are now " + total_forms_inc.toString() + " forms for " + prefix);
             total_forms.attr("value", total_forms_inc);
-            //initial_forms.attr("value", total_forms_inc);
-            initial_forms.attr("value", 0);
 
             $("<hr>").attr("style", "border: solid 1px gray").appendTo(new_form);
 
-	    //new_form.appendTo(forms).show("fast");
-	    new_form.appendTo(forms).show("fast");
+	    var nodes = $(new_form).children().detach();
+	    var new_item = $("<div class='item'>").append(nodes);
+	    new_item.appendTo(forms).show("fast");
     }
 
     function delete_form(form_div, prefix) {
@@ -126,10 +124,33 @@
         var initial_forms = mgmt_form.find("input[id=id_"+ prefix +"-INITIAL_FORMS]")
         var total_forms_dec = parseInt(total_forms.val()) - 1;
         total_forms.attr("value", total_forms_dec);
-        //initial_forms.attr("value", total_forms_dec);
-        initial_forms.attr("value", 0);
 
         $(form_div).parent().parent().parent().remove();
+
+	// update indices
+
+	var forms = $("#forms_" + prefix);
+	var items = $(forms).find(".item");
+
+	$.each(items, function(i, item) {
+	    console.log("Checking item number " + i.toString());
+	    $(item).find(":input").each(function() {
+		// replace id
+		var currentId = $(this).attr('id');
+		var newIndex = '-' + i.toString() + '-';
+		var newId = currentId.replace(/-\d-/,newIndex);
+		$(this).attr('id', newId);
+
+		// replace name
+		var currentName = $(this).attr('name');
+		var newIndex = '-' + i.toString() + '-';
+		var newName = currentName.replace(/-\d-/,newIndex);
+		$(this).attr('name', newName);
+		
+		console.log("found input with id " + currentId);
+	    });
+	});
+	
     }
 
     </script>
@@ -219,7 +240,7 @@
 			<div id="forms_{{formset.prefix}}">
 
                             {% for f in forms|get_forms:s %}
-                                <div>
+                                <div class="item">
                                    {{ f }}
                                 </div>
                             {% endfor %}


### PR DESCRIPTION
Adding items to a multisection was working before but adding dynamicallly and then removing added items within the mulitsection had multiple issues fixed in this PR ( NB. has already been fixed in the clinical forms but was overlooked in the questionnaire till now)


- adding followed by remove  doesn't garble the cdes in the item anymore
- ditto persists to new  patient ok 
- ditto updates ok to existing peatient

Also cosmetically the seperator between added items now appears consistently for all items


Additionally the "mark item for deletion" checkbox has been removed as it makes no sense on the questionnaire as all items are new and the form is only filled out once