### PR TITLE
Script for third FH data import

### DIFF
--- a/rdrf/rdrf/contexts_api.py
+++ b/rdrf/rdrf/contexts_api.py
@@ -24,58 +24,34 @@ def create_rdrf_default_contexts(patient, registry_ids):
                                                              content_type=content_type,
                                                              object_id=patient.pk).count()
 
-        logger.debug("Existing contexts count = %s" % existing_contexts_count)
-
         if existing_contexts_count == 0:
             context_manager = RDRFContextManager(registry_model)
             return context_manager.get_or_create_default_context(patient)
-        else:
-            logger.debug("not creating any default contexts")
-            for context_model in patient.context_models:
-                logger.debug("existing context model = %s" % context_model.display_name)
-
 
 class RDRFContextManager(object):
 
     def __init__(self, registry_model):
-        logger.debug("RDRFContext manager created for %s" % registry_model.code)
         self.registry_model = registry_model
         self.supports_contexts = self.registry_model.has_feature("contexts")
-        if self.supports_contexts:
-            logger.debug("reg does support contexts")
-        else:
-            logger.debug("reg does not support contexts")
 
     def get_or_create_default_context(self, patient_model, new_patient=False):
-        logger.debug("RCM: get_or_create_default_context for %s ( new = %s)" % (patient_model,
-                                                                                new_patient))
         if not self.supports_contexts:
-            logger.debug("RCM: does not support contexts")
             content_type = ContentType.objects.get_for_model(patient_model)
             contexts = [c for c in RDRFContext.objects.filter(registry=self.registry_model,
                                                               content_type=content_type,
                                                               object_id=patient_model.pk)]
             if len(contexts) == 0:
-                # No default setup so create one
-                logger.debug("RCM: creating context named default")
                 return self.create_context(patient_model, "default")
             elif len(contexts) == 1:
-                logger.debug("There already is one context so returning it")
                 return contexts[0]
             else:
-                logger.debug("More than one context - huh?!")
                 raise RDRFContextError("Patient %s in %s has more than 1 context" %
                                        (patient_model, self.registry_model))
         else:
-            logger.debug("RCM supports contexts - will create any fixed contexts")
-            logger.debug("RCM new patient - creating fixed contexts")
             default_fixed_context = self.create_fixed_contexts_for_patient(patient_model)
-            logger.debug("RCM: default fixed context = %s" % default_fixed_context)
             if default_fixed_context is not None:
-                logger.debug("RCM: is not None so returning")
                 return default_fixed_context
             else:
-                logger.debug("RCM: default fixed context is None .. creating context using create_initial_context...")
                 return self.create_initial_context_for_new_patient(patient_model)
 
     def create_fixed_contexts_for_patient(self, patient_model):

--- a/rdrf/rdrf/generalised_field_expressions.py
+++ b/rdrf/rdrf/generalised_field_expressions.py
@@ -168,6 +168,7 @@ class PokeFieldExpression(GeneralisedFieldExpression):
     # 
     
     def __init__(self, registry_model, field_expression):
+        logger.debug("init PokeFieldExpression")
         self.registry_model = registry_model
         self._parse_poke(field_expression)
 
@@ -180,7 +181,13 @@ class PokeFieldExpression(GeneralisedFieldExpression):
         self.form_model = RegistryForm.objects.get(registry=self.registry_model,
                                                    name=form_name)
         self.section_model = self._get_section_model(section_code)
-        self.cde_model = self._get_code_model(cde_code)
+        self.cde_model = self._get_cde_model(cde_code)
+
+        if self.section_model not in self.form_model.section_models:
+            raise Exception("section not in form")
+
+        if self.cde_model not in self.section_model.cde_models:
+            raise Exception("cde not in section")
 
     def _get_section_model(self, section_code):
         for section_model in self.form_model.section_models:
@@ -200,26 +207,78 @@ class PokeFieldExpression(GeneralisedFieldExpression):
 
 
     def _iterate_through_forms(self, mongo_data, **kwargs):
+        logger.debug("in iterate through forms")
+        is_setting = "value" in kwargs
+        logger.debug("is setting = %s" % is_setting)
+        
         for form_dict in mongo_data["forms"]:
+            logger.debug("checking form %s" % form_dict["name"])
             if form_dict["name"] == self.form_model.name:
+                if self.section_model.code not in [ x["code"] for x in form_dict["sections"]]:
+                    if is_setting:
+                        section_dict = {"code": self.section_model.code,
+                                        "allow_multiple": self.section_model.allow_multiple
+                                    }
+
+                        cde_dict = {"code": self.cde_model.code,
+                                    "value": kwargs["value"]}
+
+                        if self.section_model.allow_multiple:
+                            item = [cde_dict]
+                            items = [item]
+                            section_dict["cdes"] = items
+                        else:
+                            section_dict["cdes"] = [cde_dict]
+                        form_dict["sections"].append(section_dict)
+                        return True
+                    
                 for section_dict in form_dict["sections"]:
+                    logger.debug("checking section %s" % section_dict["code"])
                     if section_dict["code"] == self.section_model.code:
                         if not section_dict["allow_multiple"]:
                             raise Exception("Can't get cde in item if not a multisection")
                         else:
+                            if len(section_dict["cdes"]) == 0:
+                                logger.debug("empty items")
+                                # if we're setting, create an item with one cde
+                                if is_setting:
+                                    cde_dict = {"code": self.cde_model.code,
+                                                "value": kwargs["value"]}
+                                    item = [cde_dict]
+                                    items = [item]
+                                    section_dict["cdes"] = items
+                                    logger.debug("poked cde into a new first item")
+                                    return True
+                                
                             for item_index, cde_dict_list in enumerate(section_dict["cdes"]):
                                 num = item_index + 1
+                                logger.debug("checking item no. %s" % num)
                                 if num == self.item_number:
+                                    if is_setting:
+                                        if self.cde_model.code not in [ x["code"] for x in cde_dict_list]:
+                                            # missing cde dict in correct item
+                                            logger.debug("creating cde dict")
+                                            cde_dict = {"code": self.cde_model.code,
+                                                        "value": kwargs["value"]}
+                                            cde_dict_list.append(cde_dict)
+                                            return True
+                                        
                                     for cde_dict in cde_dict_list:
                                         if cde_dict["code"] == self.cde_model.code:
-                                            if "value" in kwargs:
+                                            if is_setting:
                                                 cde_dict["value"] = kwargs["value"]
                                                 return True
                                             else:
                                                 return cde_dict["value"]
 
-        if "value" in kwargs:
-            raise ValueError("can't update value as the cde or item doesn't exist")
+                                    if is_setting:
+                                        logger.debug("cde list = %s" % cde_dict_list)
+                                        
+
+        if is_setting:
+            logger.debug("couldn't find cde")
+            logger.debug("data = %s" % mongo_data)
+            return False
         else:
             raise ValueError("can't retrieve value")
 
@@ -240,8 +299,8 @@ class PokeFieldExpression(GeneralisedFieldExpression):
                 raise ValueError("Can't update item %s as there is no data" % self.item_number)
 
         else:
-            # this updates mongo_data
-            succeeded = self._iterate_through_forms(mongo_datavalue=new_value)
+            # this updates the clinical data
+            succeeded = self._iterate_through_forms(mongo_data, value=new_value)
             # if we couldn't poke the right item, fail
             if not succeeded:
                 raise ValueError("can't update this cde")
@@ -552,22 +611,31 @@ class GeneralisedFieldExpressionParser(object):
         return s
 
     def parse(self, field_expression):
+        logger.debug("field_expression = %s" % field_expression)
         try:
             if field_expression.startswith("Consents/"):
+                logger.debug("GFE Parser: consents")
                 return self._parse_consent_expression(field_expression)
             elif field_expression.startswith("poke/"):
+                logger.debug("GFE Parser: poke")
                 return self._parse_poke_expression(field_expression)
             elif field_expression.startswith("@"):
+                logger.debug("GFE Parser: @")
                 return self._parse_report_function_expression(field_expression)
             elif field_expression.startswith("$ms"):
+                logger.debug("GFE Parser: $ms")
                 return self._parse_ms_expression(field_expression)
             elif field_expression.startswith("Demographics/Address/"):
+                logger.debug("GFE Parser: address")
                 return self._parse_address_expression(field_expression)
             elif field_expression == "Demographics/Addresses":
+                logger.debug("GFE Parser: addresses")
                 return AddressesExpression(self.registry_model)
             elif "/" in field_expression:
+                logger.debug("GFE Parser: clinical")
                 return self._parse_clinical_form_expression(field_expression)
             elif field_expression in self.patient_fields:
+                logger.debug("GFE Parser: patient field")
                 return self._parse_patient_fields_expression(field_expression)
             else:
                 return BadColumnExpression()
@@ -585,10 +653,7 @@ class GeneralisedFieldExpressionParser(object):
     def _parse_ms_expression(self, field_expression):
         try:
             if field_expression.startswith("pick/") or field_expression.startswith("poke/"):
-                return self._parse_poke_expression(self.registry_model,
-                                                   field_expression)
-            
-                            
+                return self._parse_poke_expression(field_expression)
                                                    
             ms_designator, form_name, multisection_code, action_code = field_expression.split("/")
         except ValueError:
@@ -619,19 +684,6 @@ class GeneralisedFieldExpressionParser(object):
                                                section_model)
         else:
             raise FieldExpressionError("ms expression not understood: %s" % field_expression)
-
-    def _parse_poke_expression(self, field_expression, registry_model):
-        form_model = None
-        section_model = None
-        cde_model = None
-        operation = None
-        
-        return CDEInMultiSectionItemExpression(registry_model,
-                                               form_model,
-                                               section_model,
-                                               cde_model,
-                                               operation)
-    
 
     def _parse_consent_expression(self, consent_expression):
         """

--- a/scripts/cdeimport.py
+++ b/scripts/cdeimport.py
@@ -329,8 +329,9 @@ class PatientUpdater:
                                                     field_expression,
                                                     value=rdrf_value)
         else:
-            info("will not update multisection %s with bad value [%s]" % (field_info,
-                                                                          rdrf_value))
+            if rdrf_value is not None:
+                info("will not update multisection %s with bad value [%s]" % (field_info,
+                                                                              rdrf_value))
 def usage():
     print("usage: python cdeimport.py <registry code> <field map file> <id map file> <data file csv>")
 

--- a/scripts/fh3_import.py
+++ b/scripts/fh3_import.py
@@ -242,7 +242,7 @@ class PatientUpdater:
     def _update_multisection(self, field_info, rdrf_value, patient_model):
         # assumption from sheet is that we are updating the 1st item of the multisection
         # if none exists, we create the multisection item
-        pass
+        field_expression = "%s/%s
     
                                 
 
@@ -265,6 +265,5 @@ if __name__ == '__main__':
     blank_lines(2)
 
     rows = read_patients(csv_file)
-
     patient_updater = PatientUpdater(registry_model, field_map, id_map, rows)
     patient_updater.update()

--- a/scripts/fh3_import.py
+++ b/scripts/fh3_import.py
@@ -176,12 +176,6 @@ class PatientUpdater:
                                                     new_id))
             return None
 
-    def _get_field_data(self, row):
-        for column_index in range(1, self.last_column + 1):
-            field_info = self._get_column_info(column_index)
-            raw_value = row[column_index]
-            yield field_info, raw_value
-
     def _get_column_info(self, column_index):
         return self.field_map[column_index]
 
@@ -191,10 +185,8 @@ class PatientUpdater:
                                                     field_expression,
                                                     value=rdrf_value)
         else:
+            # if data not supplied, we don't attempt to import
             info("Not applying empty value for this field")
-            
-
-        
 
     def _get_rdrf_value(self, value, field_info):
         if field_info.is_range:
@@ -218,6 +210,8 @@ class PatientUpdater:
                             error("No field info for column %s" % column_key)
                             continue
                         else:
+                            if field_info.is_multi:
+                                continue
                             info(
                                 "found field info for column %s: %s" % (column_key,
                                                                         field_info))
@@ -228,7 +222,6 @@ class PatientUpdater:
                                 raw_value, field_info)
 
                             field_expression = field_info.field_expression
-                            
 
                             if not field_info.in_multi:
                                 
@@ -236,9 +229,21 @@ class PatientUpdater:
                                                              field_expression,
                                                              patient_model,
                                                              rdrf_value)
+
+                                
                             else:
                                 info("dummy updating cde in mulisection %s --> %s" % (field_expression,
                                                                                       rdrf_value))
+
+                                self._update_multisection(field_info,
+                                                          rdrf_value,
+                                                          patient_model)
+
+    def _update_multisection(self, field_info, rdrf_value, patient_model):
+        # assumption from sheet is that we are updating the 1st item of the multisection
+        # if none exists, we create the multisection item
+        pass
+    
                                 
 
 

--- a/scripts/fh3_import.py
+++ b/scripts/fh3_import.py
@@ -1,0 +1,164 @@
+import django
+django.setup()
+
+import sys
+from operator import itemgetter
+from django.db import transaction
+from rdrf.models import Registry
+from rdrf.models import CommonDataElement
+from rdrf.models import CDEPermittedValue
+
+from registry.patients.models import Patient
+
+class MissingCodeError(Exception):
+    pass
+
+
+class Codes:
+    FORM = "ClinicalData"
+    MULTISECTION = "FHMutationDetails"
+    GENEVARIANT = "FHMutation"
+    DESCRIPTION = "FHMutationDescription"
+    PATHOGENICITY = "Pathogenicity"
+
+class PatientData:
+    def __init__(self, patient_id, items):
+        self.old_id = patient_id
+        self.items = items
+
+class Reader:
+    def __init__(self, csv_file):
+        self.csv_file = csv_file
+        self.patient_data = []
+        
+    def read(self):
+        import csv
+        patient_map = {}
+        with open(self.csv_file) as f:
+            csvreader = csv.DictReader(f)
+            for row in csvreader:
+                if row["PatientID"] in patient_map:
+                    patient_map[row["PatientID"]].append(row)
+                else:
+                    patient_map[row["PatientID"]] = [row]
+        for patient_id in patient_map:
+            items = self._make_items(patient_id, patient_map[patient_id])
+            self.patient_data.append(PatientData(patient_id, items))
+
+
+    def _make_items(self, patient_id, rows):
+        items = []
+        for row in sorted(rows,key=itemgetter('SectionIndex')):
+            cde_dicts = []
+            if row["GeneVariant"]:
+                cde_dicts.append(self._make_cde_dict(Codes.GENEVARIANT,
+                                                     row["GeneVariant"]))
+
+            if row["Description"]:
+                cde_dicts.append(self._make_cde_dict(Codes.DESCRIPTION,
+                                                     row["Description"]))
+
+            if row["Pathogenicity"]:
+                cde_dicts.append(self._make_cde_dict(Codes.PATHOGENICITY,
+                                                     row["Pathogenicity"]))
+
+            items.append(cde_dicts)
+
+        return items
+
+    def _make_cde_dict(self, code, display_value):
+        cde_model = CommonDataElement.objects.get(code=code)
+        if cde_model.pv_group:
+            # need to get the value code from  the display value provided
+            try:
+                value = self._get_pv_code(cde_model.pv_group,
+                                          display_value)
+            except MissingCodeError:
+                error("Missing code for pvg %s display_value '%s'" % (cde_model.pv_group.code,
+                                                                      display_value))
+                value = None
+                
+        else:
+            value = display_value
+
+            
+            
+        return {"code": code,
+                "value": value}
+
+    def _get_pv_code(self, pv_group, display_value):
+        for pv in CDEPermittedValue.objects.filter(
+                pv_group=pv_group).order_by('position'):
+            if pv.value == display_value:
+                return pv.code
+
+        raise MissingCodeError()
+
+        
+
+    
+    def __iter__(self):
+        for data in self.patient_data:
+            yield data
+           
+def build_idmap(mapfile):
+    idmap = {}
+    with open(mapfile) as mf:
+        for line in mf.readlines():
+            old_id, new_id = line.strip().split(",")
+            idmap[old_id] = new_id
+    return idmap
+
+def error(msg):
+    print("Error: %s" % msg)
+
+def info(msg):
+    print("Info: %s" % msg)
+
+def existing_data(patient_model):
+    return False 
+    
+    
+idmap_file = sys.argv[1]
+csv_file = sys.argv[2]
+
+fh_registry = Registry.objects.get(code="fh")
+
+reader = Reader(csv_file)
+reader.read()
+
+idmap = build_idmap(idmap_file)
+
+# we're updating just one multisection
+field_expression = "$ms/%s/%s/items" % (Codes.FORM,
+                                        Codes.MULTISECTION)
+
+for patient_data in reader:
+    rdrf_id = idmap.get(patient_data.old_id, None)
+    if rdrf_id is None:
+        error("Patient %s does not exist in mapping file" % patient_data.old_id)
+        continue
+    else:
+        try:
+            patient_model = Patient.objects.get(pk=rdrf_id)
+            moniker = "%s\%s" % (patient_data.old_id,
+                                 rdrf_id)
+            
+            info("Found patient %s" % patient_model)
+            
+
+            info("Updating patient %s .." % moniker)
+
+            try:
+                with transaction.atomic():
+                    patient_model.evaluate_field_expression(fh_registry,
+                                                            field_expression,
+                                                            value=patient_data.items)
+                
+                    info("Updated patient %s OK" % moniker)
+            except Exception as ex:
+                    error("Updated failed for %s ( no change to this patient): %s" % (moniker,
+                                                                                      ex))
+                    
+        except Patient.DoesNotExist:
+            error("No patient with id %s - skipping" % rdrf_id)


### PR DESCRIPTION

usage:
```bash
python /app/scripts/cdeimport.py <registry code> <field map file> <id map file> <data file csv>   > results.log
```

where

field map is a csv mapping the "field numbers" we provided the client to form name, section code, cde codes in the registry

id map is a mapping csv file of the client's "id for patients" to our id

( hence this is an updater and relies on the patient already having an id in rdrf )

The script updates any cde values and assumes the first item of a multisection is being updated ( for fh the biochemistry profile. )

The script runs each patient update in its own transaction  and rolls back on any unhandled error.

Produces a log of each update ( any "bad" values which are not "empty" /unfilled in values from the csv are logged

Then a set of stats is printed at the end:
E.g.
```bash
INFO: STATS:
INFO: Rows:      583
INFO: Updates:   582
INFO: Rollbacks: 1
INFO: Missing:   1
INFO: RUN FINISHED
```
Missing means that the patient in the datafile did not have an entry in the mapping file OR that it was mapped but there was no patient for the corresponding RDRF patient id ( the log will record which before the stats section)

The code uses the same "field expression" syntax as in previous imports  to update arbitrary cdes in RDRF.

Whether "field expressions" are ultimately a good idea is debatable - they were developed for reporting ( one the DM1 spreadsheet reports) where a string expression like:

```python
clinicalform/sectioncode/cdecode
```

can be used in a spread template cell to pull out a value from system

The generalisation to setting a value using this path like notation seemed natural enough at the time.

For mutlisections it gets more unwieldy , for this script I added another expression like
```python
poke/formname/sectioncode/1/cdecode
```

which "pokes" the cde value of the 1st item in  multisection with section code sectioncode 

( if there is no item, it creates one; poking into 2 will error though if the second does not exist)




