### PR TITLE
Questionnaire Validation Improvements

### DIFF
--- a/rdrf/rdrf/templates/rdrf_cdes/base_questionnaire.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/base_questionnaire.html
@@ -47,31 +47,32 @@
         
     </head>
     <script>
-      // scroll to any validation errors
-      $(document).ready(function() {
+        $(document).ready(function() {
 
-      (function() {
-      var delay = 0;
-      var offset = 150;
+            var delay = 0;
+            var offset = 150;
 
-      document.addEventListener('invalid', function(e){
-          $(e.target).addClass("invalid");
-          $('html, body').animate({scrollTop: $($(".invalid")[0]).offset().top - offset }, delay);
-      }, true);
-      
-      document.addEventListener('change', function(e){
-          $(e.target).removeClass("invalid")
-      }, true);
+            document.addEventListener('invalid', function(e) {
+                $(e.target).addClass("invalid");
+                $('html, body').animate({
+                    scrollTop: $($(".invalid")[0]).offset().top - offset
+                }, delay);
+            }, true);
 
-      // if we posting back Django errors - scroll to errorlist
-      $('html, body').animate({scrollTop: $($(".errorlist")[0]).offset().top - offset }, delay);
-      
+            document.addEventListener('change', function(e) {
+                $(e.target).removeClass("invalid")
+            }, true);
 
-      
-
-      })();
-      });
-     </script>
+            // if we're posting back Django errors - scroll to errorlist
+	    try {
+                $('html, body').animate({
+                    scrollTop: $($(".errorlist")[0]).offset().top - offset
+                }, delay);
+	    }
+	    catch(err) {
+	    };
+        });
+    </script>
 
     <body style="background-color: #edeff1; padding-top: 80px; padding-bottom: 30px;">
 

--- a/rdrf/rdrf/templates/rdrf_cdes/base_questionnaire.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/base_questionnaire.html
@@ -30,7 +30,19 @@
                 table {
                     table-layout: fixed;
                 }
+
+		ul.errorlist {
+		    display: block;
+		    padding: 15px;
+		    margin-bottom: 20px;
+		    border: 1px solid transparent;
+		    border-radius: 4px;
+		    color: #a94442;
+		    background-color: #f2dede;
+		    border-color: #ebccd1;
+		}
             </style>
+
         {% endblock %}
         
     </head>
@@ -50,6 +62,12 @@
       document.addEventListener('change', function(e){
           $(e.target).removeClass("invalid")
       }, true);
+
+      // if we posting back Django errors - scroll to errorlist
+      $('html, body').animate({scrollTop: $($(".errorlist")[0]).offset().top - offset }, delay);
+      
+
+      
 
       })();
       });

--- a/rdrf/rdrf/templates/rdrf_cdes/base_questionnaire.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/base_questionnaire.html
@@ -34,6 +34,26 @@
         {% endblock %}
         
     </head>
+    <script>
+      // scroll to any validation errors
+      $(document).ready(function() {
+
+      (function() {
+      var delay = 0;
+      var offset = 150;
+
+      document.addEventListener('invalid', function(e){
+          $(e.target).addClass("invalid");
+          $('html, body').animate({scrollTop: $($(".invalid")[0]).offset().top - offset }, delay);
+      }, true);
+      
+      document.addEventListener('change', function(e){
+          $(e.target).removeClass("invalid")
+      }, true);
+
+      })();
+      });
+     </script>
 
     <body style="background-color: #edeff1; padding-top: 80px; padding-bottom: 30px;">
 

--- a/rdrf/rdrf/templates/rdrf_cdes/questionnaire.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/questionnaire.html
@@ -176,7 +176,11 @@
 
     <p>
     </p>
-    <div class="alert alert-danger" id="msg-box">{% trans 'Red fields are required' %}</div>
+    <br>
+    <br>
+    
+    <div class="text-center alert" id="msg-box"><b>Fields with an asterisk (<span class="glyphicon glyphicon-asterisk" style="color: red;" aria-hidden="true"></span>) are required.</b>
+    </div>
 
     <form enctype="multipart/form-data" class="form" method="post" id="questionnaire-form">{% csrf_token %}
 
@@ -256,8 +260,14 @@
                             {% autoescape off %}
                                 {% get_form_var forms s as form %}
                                 {% for field in form %}
-                                    <tr class="{{ field.field.required|yesno:"danger," }}">
-                                        <td style="width: 40%; vertical-align: middle;">{{ field.label }}</td>
+                                    <tr>
+                                        <td style="width: 40%; vertical-align: middle;">
+                                             {{ field.label }}
+                                             {% if  field.field.required %}
+                                                 <span class="glyphicon glyphicon-asterisk" style="color: red;" aria-hidden="true"></span>
+                                             {% endif %}
+
+                                        </td>
                                         <td>
                                                 {{field}}
                                         </td>


### PR DESCRIPTION
If there are required field errors, the error is scrolled to automatically.
The missing address field errors  outlined in red ( same styling as the consent validation) and scrolled to.
Instead of the red table row for required fields I've made the questionnaire use red asterisks ( as we use in the application.)

