### PR TITLE
don't initialise django app within tasks.py

### DIFF
--- a/rdrf/rdrf/urls.py
+++ b/rdrf/rdrf/urls.py
@@ -4,6 +4,7 @@ from django.shortcuts import render
 from django.views.generic.base import TemplateView
 import django.contrib.auth.views
 from django.views.i18n import JavaScriptCatalog
+from django.conf import settings
 
 import rdrf.form_view as form_view
 import rdrf.registry_view as registry_view
@@ -27,9 +28,16 @@ from rdrf.lookup_views import RecaptchaValidator
 from rdrf.context_views import RDRFContextCreateView, RDRFContextEditView
 from rdrf import patients_listing
 
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 # very important so that registry admins (genetic, patient, etc) are discovered.
 admin.autodiscover()
 
+def handlerException(request):
+    raise Exception("Forced exception in /raise")
 
 def handler404(request):
     return render(request, "404.html")
@@ -46,11 +54,17 @@ def handlerApplicationError(request):
 
 JavaScriptCatalog.domain = "django"  # The default domain didn't work for me
 
-urlpatterns = [
+urlpatterns = []
+if settings.DEBUG is True:
+    urlpatterns += [
+        url(r'^test404', handler404, name='test 404'),
+        url(r'^test500', handler500, name='test 500'),
+        url(r'^testAppError', handlerApplicationError, name='test application error'),
+        url(r'^raise', handlerException, name='test exception'),
+    ]
+
+urlpatterns += [
     url(r'^translations/jsi18n/$', JavaScriptCatalog.as_view(), name='javascript-catalog'),
-    url(r'^test404', handler404),
-    url(r'^test500', handler500),
-    url(r'^testAppError', handlerApplicationError),
     url(r'^iprestrict/', include('iprestrict.urls')),
     url(r'^useraudit/', include('useraudit.urls')),
 
@@ -194,3 +208,4 @@ urlpatterns = [
 
     url(r'^i18n/', include('django.conf.urls.i18n')),
 ]
+

--- a/rdrf/tasks.py
+++ b/rdrf/tasks.py
@@ -1,7 +1,7 @@
 """
 Define events for use with the uWSGI cron-like interface (https://uwsgi-docs.readthedocs.io/en/latest/Cron.html)
 
-Care must be taken with Django imports. We want application initiliasation to be triggered by the web application
+Care must be taken with Django imports. We want application initialisation to be triggered by the web application
 not by this file. Hence we are checking to see if the django app is ready before performing some imports.
 
 """
@@ -19,7 +19,7 @@ def django_cron_heartbeat(num):
     """
     A heartbeat for django-cron (https://github.com/Tivix/django-cron)
     """
-    if apps.apps_ready is not True:
+    if not apps.apps_ready:
         # Django is not initialised, the logger config in settings will not be active
         print("Deferring calling django-cron heartbeat until django app is ready")
         return

--- a/rdrf/tasks.py
+++ b/rdrf/tasks.py
@@ -1,10 +1,12 @@
 """
 Define events for use with the uWSGI cron-like interface (https://uwsgi-docs.readthedocs.io/en/latest/Cron.html)
 
+Care must be taken with Django imports. We want application initiliasation to be triggered by the web application
+not by this file. Hence we are checking to see if the django app is ready before performing some imports.
+
 """
 from django_uwsgi.decorators import timer
-from django.core.management import call_command
-from django.conf import settings
+from django.apps import apps
 import io
 import logging
 
@@ -12,21 +14,18 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-import django
-django.setup()
-
-
-if settings.DEBUG:
-    @timer(60)
-    def debug_timer(num):
-        logger.debug("")
-
-
 @timer(300)
 def django_cron_heartbeat(num):
     """
     A heartbeat for django-cron (https://github.com/Tivix/django-cron)
     """
+    if apps.apps_ready is not True:
+        # Django is not initialised, the logger config in settings will not be active
+        print("Deferring calling django-cron heartbeat until django app is ready")
+        return
+
+    # Do not perform this import until the django app is ready
+    from django.core.management import call_command
     out_stream = io.StringIO("")
     call_command('runcrons', stdout=out_stream)
     logger.info(out_stream.getvalue())


### PR DESCRIPTION
Recently added tasks.py was triggering django initialisation, which is not what we want in prod. Initialisation of Django needs to take place in the web app.