### PR TITLE
Email notification resend for account activation doesn't reset token …

### DIFF
--- a/rdrf/rdrf/events.py
+++ b/rdrf/rdrf/events.py
@@ -6,3 +6,6 @@ class EventType:
     ACCOUNT_VERIFIED = "account-verified"
     REMINDER = "reminder"
 
+    @classmethod
+    def is_registration(cls, evt):
+        return evt in (cls.NEW_PATIENT, cls.NEW_PATIENT_PARENT)


### PR DESCRIPTION
#448

There is no activation key expiration date in `django-registration-redux`. The `user.date_joined` is used to calculate the activation expiry.

Solution will reset `date_joined` to today if the account hasn't been activated yet.
If the account has been activated only the email is sent out.

