### PR TITLE
Changing login incorrect msg to warn users they will be locked out. #940

### DIFF
--- a/rdrf/rdrf/auth.py
+++ b/rdrf/rdrf/auth.py
@@ -1,0 +1,30 @@
+import logging
+
+from django.contrib.auth.forms import AuthenticationForm
+from django.conf import settings
+from django.utils.translation import ugettext as _
+
+
+logger = logging.getLogger(__name__)
+
+
+_login_failure_limit = getattr(settings, 'LOGIN_FAILURE_LIMIT', 0)
+
+
+_msg_default = 'Please enter a correct %(username)s and password (case-sensitive).'
+_msg_limit = ('For security reasons, accounts are temporarily locked after '
+              '%(login_failure_limit)d incorrect attempts.' % {'login_failure_limit' : _login_failure_limit})
+
+# Making sure both text are available for translators indepenedent on the current LOGIN_FAILURE_LIMIT setting
+_MSG_NO_LIMIT = _(_msg_default)
+_MSG_WITH_LIMIT = _(_msg_default + ' ' + _msg_limit)
+
+
+class RDRFAuthenticationForm(AuthenticationForm):
+    error_messages = AuthenticationForm.error_messages
+
+    _invalid_login_msg = _MSG_WITH_LIMIT if _login_failure_limit > 0 else _MSG_NO_LIMIT
+
+    error_messages.update({
+        'invalid_login': _(_invalid_login_msg)
+    })

--- a/rdrf/rdrf/urls.py
+++ b/rdrf/rdrf/urls.py
@@ -6,6 +6,7 @@ import django.contrib.auth.views
 from django.views.i18n import JavaScriptCatalog
 from django.conf import settings
 
+from rdrf.auth import RDRFAuthenticationForm
 import rdrf.form_view as form_view
 import rdrf.registry_view as registry_view
 import rdrf.landing_view as landing_view
@@ -94,7 +95,7 @@ urlpatterns += [
         RDRFContextEditView.as_view(),
         name="context_edit"),
     url(r'^login/?$', django.contrib.auth.views.login,
-        kwargs={'template_name': 'admin/login.html'}, name='login'),
+        kwargs={'template_name': 'admin/login.html', 'authentication_form': RDRFAuthenticationForm}, name='login'),
     url(r'^router/', login_router.RouterView.as_view(), name="login_router"),
 
     url(r"^(?P<registry_code>\w+)/forms/(?P<form_id>\w+)/(?P<patient_id>\d+)/(?P<context_id>add)/?$",


### PR DESCRIPTION
Addresses muccg/rdrf-ccg#940 partially, started a discussion on the rest of that issue.

This one just changes the invalid login message a bit to warn users that their account will be locked after `LOGIN_FAILURE_LIMIT` incorrect attempts.



