### PR TITLE
Ajax patient listing

### DIFF
--- a/rdrf/rdrf/components.py
+++ b/rdrf/rdrf/components.py
@@ -422,3 +422,46 @@ class FormsButton(RDRFComponent):
                 return self.context_form_group.forms[0].nice_name + "s"
             else:
                 return self.context_form_group.name
+
+
+
+class FormGroupButton(RDRFComponent):
+    """
+    A button which when clicked, loads a patient's forms
+    via Ajax.
+    """
+    
+    TEMPLATE = "rdrf_cdes/form_group_button_component.html"
+    def __init__(self, registry_model, user, patient_model, context_form_group):
+        self.registry_model = registry_model
+        self.user = user
+        self.patient_model = patient_model
+        self.context_form_group = context_form_group
+
+    def _get_template_data(self):    
+        if self.context_form_group is None:
+            form_group_id = None
+            registry_type = "normal"
+        else:
+            form_group_id = self.context_form_group.id
+            registry_type = "has_groups"
+            
+            
+        return {"button_caption": self.button_caption,
+                "patient_id": self.patient_model.id,
+                "form_group_id": form_group_id,
+                "registry_type": registry_type}
+
+    @property
+    def button_caption(self):
+        if self.context_form_group is None:
+            return "Modules"
+        else:
+            if self.context_form_group.supports_direct_linking:
+                # we know there is one form
+                return self.context_form_group.forms[0].nice_name + "s"
+            else:
+                return self.context_form_group.name
+
+
+

--- a/rdrf/rdrf/components.py
+++ b/rdrf/rdrf/components.py
@@ -365,9 +365,13 @@ class FormsButton(RDRFComponent):
         else:
             heading = "Modules"
 
+        add_link, add_link_text = self._get_add_link()
+
         return {
             "heading": heading,
             "forms": self._get_form_link_wrappers(),
+            "add_link": add_link,
+            "add_link_text": add_link_text,
         }
 
     def _get_form_link_wrappers(self):
@@ -400,7 +404,6 @@ class FormsButton(RDRFComponent):
             
             context_models = self.patient_model.get_multiple_contexts(self.context_form_group)
             context_models = context_models[:self.MULTIPLE_LIMIT]
-            
 
             return [
                 self.FormWrapper(self.registry_model,
@@ -416,6 +419,12 @@ class FormsButton(RDRFComponent):
             return 0
         else:
             return self.context_form_group.pk
+
+    def _get_add_link(self):
+        if self.context_form_group and self.context_form_group.context_type == "M":
+            link_url, link_text = self.context_form_group.get_add_action(self.patient_model)
+            return link_url, link_text
+        return None, None
 
     @property
     def button_caption(self):

--- a/rdrf/rdrf/components.py
+++ b/rdrf/rdrf/components.py
@@ -299,6 +299,7 @@ class FormsButton(RDRFComponent):
     A button/popover which pressed shows links to forms in a registry or a form group
     """
     TEMPLATE = "rdrf_cdes/forms_button.html"
+    MULTIPLE_LIMIT = 10 # Only show the last <MULTIPLE_LIMIT> items for multiple context form groups
 
     class FormWrapper(object):
 
@@ -395,7 +396,11 @@ class FormsButton(RDRFComponent):
         else:
             # multiple group
             # we may have more than one assessment etc
+            # NB. We LIMIT the number of forms shown to the last 10
+            
             context_models = self.patient_model.get_multiple_contexts(self.context_form_group)
+            context_models = context_models[:self.MULTIPLE_LIMIT]
+            
 
             return [
                 self.FormWrapper(self.registry_model,

--- a/rdrf/rdrf/models.py
+++ b/rdrf/rdrf/models.py
@@ -1550,7 +1550,8 @@ class ContextFormGroup(models.Model):
         if self.patient_can_add(patient_model):
             num_forms = len(self.form_models)
             # Direct link to form if num forms is 1 ( handler redirects transparently)
-            action_title = "Add %s" % self.form_models[0].name if num_forms == 1 else "Add %s" % self.name
+            from rdrf.utils import de_camelcase as dc
+            action_title = "Add %s" % dc(self.form_models[0].name) if num_forms == 1 else "Add %s" % dc(self.name)
 
             if not self.supports_direct_linking:
                 # We can't go directly to the form - so we first land on the add context view, which on save

--- a/rdrf/rdrf/patients_listing.py
+++ b/rdrf/rdrf/patients_listing.py
@@ -18,9 +18,11 @@ from rdrf.models import Registry
 from rdrf.form_progress import FormProgress
 from rdrf.contexts_api import RDRFContextManager
 from rdrf.components import FormsButton
+from rdrf.components import FormGroupButton
 from registry.patients.models import Patient
 from .utils import Message
 from rdrf.utils import MinType
+from rdrf.utils import timed
 from django.utils.translation import ugettext as _
 
 
@@ -155,6 +157,7 @@ class PatientsListingView(View):
         return HttpResponse(json_data, content_type="application/json")
 
     ########################   POST #################################
+    @timed
     def post(self, request):
         # see http://datatables.net/manual/server-side
         self.user = request.user
@@ -525,7 +528,7 @@ class ColumnContextMenu(Column):
             self.multiple_form_groups = registry.multiple_form_groups
             
     def cell(self, patient, supports_contexts=False, form_progress=None, context_manager=None):
-        return "".join(self._get_forms_buttons(patient))
+        return " ".join(self._get_forms_buttons(patient))
 
     def _get_forms_buttons(self, patient, form_progress=None, context_manager=None):
         
@@ -549,18 +552,8 @@ class ColumnContextMenu(Column):
             return buttons
 
     def _get_forms_button(self, patient_model, context_form_group, forms):
-        
-        button = FormsButton(self.registry, self.user, patient_model,
-                             context_form_group, [f for f in forms if f.applicable_to(patient_model)])
-
-        return """
-            <div class="dropdown">
-                <button class="btn btn-primary btn-sm dropdown-toggle" type="button" id="forms_button_%s" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                    %s <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu" aria-labelledby="forms_button_%s">%s</ul>
-            </div>
-        """ % (button.id, _(button.button_caption), button.id, button.html)
+        button = FormGroupButton(self.registry, self.user, patient_model, context_form_group)
+        return button.html
 
     def sort_key(self, *args, **kwargs):
         return None

--- a/rdrf/rdrf/rpc_commands.py
+++ b/rdrf/rdrf/rpc_commands.py
@@ -198,3 +198,69 @@ def rpc_create_patient_from_questionnaire(request, questionnaire_response_id):
             "patient_name": "%s" % created_patient,
             "patient_link": patient_link,
             "patient_blurb": patient_blurb}
+
+def rpc_get_forms_list(request, registry_code, patient_id, form_group_id):
+    from rdrf.models import ContextFormGroup
+    from rdrf.models import Registry
+    from registry.patients.models import Patient
+    from rdrf.security_checks import security_check_user_patient
+    from django.core.exceptions import PermissionDenied
+    from rdrf.components import FormsButton
+    from django.utils.translation import ugettext as _
+
+    user = request.user
+    fail_response = {"status": "fail", "message": _("Data could not be retrieved")}
+
+    try:
+        registry_model = Registry.objects.get(code=registry_code)
+    except Registry.DoesNotExist:
+        return fail_response
+    
+    try:
+        patient_model = Patient.objects.get(id=patient_id)
+    except Patient.DoesNotExist:
+        return fail_response
+
+    try:
+        security_check_user_patient(user, patient_model)
+    except PermissionDenied:
+        return fail_response
+
+    if not patient_model.in_registry(registry_model.code):
+        return fail_response
+
+    if not user.is_superuser and not user.in_registry(registry_model):
+        return fail_response
+
+    if form_group_id is not None:
+        try:
+            context_form_group = ContextFormGroup.objects.get(id=form_group_id)
+        except ContextFormGroup.DoesNotExist:
+            logger.debug("cfg does not exist")
+            return fail_response
+    else:
+        context_form_group = None
+        
+    forms = context_form_group.forms if context_form_group else registry_model.forms
+    
+    form_models = [f for f in forms
+                   if f.applicable_to(patient_model) and user.can_view(f)]
+
+    html = FormsButton(registry_model,
+                       user,
+                       patient_model,
+                       context_form_group,
+                       form_models).html
+
+    return {"status": "success",
+            "html": html}
+
+
+    
+
+    
+
+    
+    
+
+    

--- a/rdrf/rdrf/templates/rdrf_cdes/form_group_button_component.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/form_group_button_component.html
@@ -1,0 +1,15 @@
+{% load static %}
+{% load i18n %}
+{% load translate %}
+<div class="dropdown" >
+  <button class="btn btn-sm btn-outline-dark btn-block  dropdown-toggle patient-forms-button" id="forms_button_{{patient_id}}" type="button"
+	  data-toggle="dropdown"
+	  data-patient="{{ patient_id }}"
+	  data-formgroup="{{ form_group_id }}"
+	  aria-haspopup="true"
+	  aria-expanded="false">
+    {% trans button_caption %}
+    <span class="caret"></span>
+</button>
+<ul class="dropdown-menu forms-list" aria-labelledby="forms_button_{{patient_id}}"></ul>
+</div>

--- a/rdrf/rdrf/templates/rdrf_cdes/forms_button.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/forms_button.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load i18n %}
 {% load translate %}
 
 {% for form in forms %}
@@ -15,3 +16,7 @@
 		  {{form.title|translate}}</a>
 	</li>
 {% endfor %}
+{% if add_link %}
+     <li><a href="{{add_link}}">{% trans add_link_text %}</a></li>
+{% endif %}
+	

--- a/rdrf/rdrf/templates/rdrf_cdes/patients_listing.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/patients_listing.html
@@ -6,175 +6,171 @@
 
 {% block extrastyle %}
     {{ block.super }}
-     <link rel="stylesheet" href="{% static 'datatables-1.10.12/css/jquery.dataTables.min.css' %}">
-     <script type="text/javascript" src="{% static 'datatables-1.10.12/js/jquery.dataTables.min.js' %}"></script>
-
+    <link rel="stylesheet" href="{% static 'datatables-1.10.12/css/jquery.dataTables.min.css' %}">
+    <script type="text/javascript" src="{% static 'datatables-1.10.12/js/jquery.dataTables.min.js' %}"></script>
     <script>
+        $(document).ready(function () {
+            $.fn.dataTable.ext.errMode = 'throw';
 
-        $(document).ready(function() {
-
-        $.fn.dataTable.ext.errMode = 'throw';
-
-        var initialPatientId = "{{patient_id}}";
-        var contextFormGroupId = "{{context_form_group_id}}";
-        var CONTEXT_LINK_COLUMN_INDEX= 2;
-        var CONTEXT_CREATED_DATE_COLUMN_INDEX =  3;
-        var CONTEXT_COLUMNS = [CONTEXT_LINK_COLUMN_INDEX, CONTEXT_CREATED_DATE_COLUMN_INDEX];
+            var initialPatientId = "{{patient_id}}";
+            var contextFormGroupId = "{{context_form_group_id}}";
+            var CONTEXT_LINK_COLUMN_INDEX = 2;
+            var CONTEXT_CREATED_DATE_COLUMN_INDEX = 3;
+            var CONTEXT_COLUMNS = [CONTEXT_LINK_COLUMN_INDEX, CONTEXT_CREATED_DATE_COLUMN_INDEX];
 
 
-        var api_url = "{% url 'patientslisting'  %}";
-        var rpc = new RPC.RPC("{% url 'rpc' %}", "{{csrf_token}}");
+            var api_url = "{% url 'patientslisting'  %}";
+            var rpc = new RPC.RPC("{% url 'rpc' %}", "{{csrf_token}}");
 
-        $("contextmenu").popover({html: true});
+            $("contextmenu").popover({ html: true });
 
-        $.ajaxSetup({beforeSend: function (xhr) {
+            $.ajaxSetup({
+                beforeSend: function (xhr) {
                     var csrfToken = '{{ csrf_token }}';
                     xhr.setRequestHeader('X-CSRFToken', csrfToken);
-        }});
+                }
+            });
 
-        function wireUpFormsButtons() {
+            function wireUpFormsButtons() {
 
-	    $(".patient-forms-button").click(function() {
-		var button = $(this);
-		var registryCode = getSelectedRegistry();
+                $(".patient-forms-button").click(function () {
+                    var button = $(this);
+                    var registryCode = getSelectedRegistry();
 
-		function showFormsList(html) {
-		    var ul = button.parent().find("ul.dropdown-menu");
-		    if(html.indexOf("<li>") == -1) html = "<li>No Data</li>";
-		    $(ul).html(html);
-		}
-	    
-		var patientId = parseInt(button.data("patient"));
-		var formGroupId = parseInt(button.data("formgroup"));
+                    function showFormsList(html) {
+                        var ul = button.parent().find("ul.dropdown-menu");
+                        if (html.indexOf("<li>") == -1) html = "<li>No Data</li>";
+                        $(ul).html(html);
+                    }
 
-		rpc.send("get_forms_list", [registryCode, patientId, formGroupId], function(response) {
-                    if (response.status != "fail") {
-	                var status = response.result.status;
-	                if (status == "success") {
-	                   var html= response.result.html;
-	                   showFormsList(html);
-	                }
-	            }
-	        });
-	  });
-	}
+                    var patientId = parseInt(button.data("patient"));
+                    var formGroupId = parseInt(button.data("formgroup"));
 
-        function getDrawLength() {
-            try {
-                var length = $("#patients_table_length").val();
-                if (length == undefined || length == "") {
+                    rpc.send("get_forms_list", [registryCode, patientId, formGroupId], function (response) {
+                        if (response.status == "fail") {
+                            alert(response.error);
+
+                        } else {
+                            var html = response.result.html;
+                            showFormsList(html);
+                        }
+                    });
+
+
+                });
+            }
+
+            function getDrawLength() {
+                try {
+                    var length = $("#patients_table_length").val();
+                    if (length == undefined || length == "") {
+                        return 10;
+                    }
+                    return length;
+                }
+
+                catch (err) {
                     return 10;
                 }
-                return length;
             }
 
-            catch(err) {
-                return 10;
-            }
-        }
-
-        function getSelectedRegistry() {
-            var code = $("#registry_options > option:selected").attr('id');
-            return code;
-        }
-
-        function getApiUrl(registryCode, drawLength) {
-            var url;
-
-            if (initialPatientId=='None'){
-                url =   api_url + "?registry_code=" + registryCode +
-                    "&length=" + drawLength;
-            }
-            else {
-                url =   api_url + "?registry_code=" + registryCode +
-                    "&length=" + drawLength + "&patient_id=" + initialPatientId;
+            function getSelectedRegistry() {
+                var code = $("#registry_options > option:selected").attr('id');
+                return code;
             }
 
-            if (contextFormGroupId != 'None') {
-                url += "&context_form_group_id=" + contextFormGroupId;
+            function getApiUrl(registryCode, drawLength) {
+                var url;
+
+                if (initialPatientId == 'None') {
+                    url = api_url + "?registry_code=" + registryCode +
+                        "&length=" + drawLength;
+                }
+                else {
+                    url = api_url + "?registry_code=" + registryCode +
+                        "&length=" + drawLength + "&patient_id=" + initialPatientId;
+                }
+
+                if (contextFormGroupId != 'None') {
+                    url += "&context_form_group_id=" + contextFormGroupId;
+                }
+
+                return url;
             }
 
-            return url;
-        }
+            if ({{ registries.0| has_feature:"no_add_patient_button" | yesno:"false,true" }} == false) {
+                $("#add_patient").hide();
+            }
 
-        if ( {{ registries.0|has_feature:"no_add_patient_button"|yesno:"false,true" }} == false) {
-            $("#add_patient").hide();
-        }
+            var registryCode = getSelectedRegistry();
 
-        var registryCode = getSelectedRegistry();
-
-        var load_contexts_list;
-        var context_list;
-        {% if columns %}
-            context_list = $("#patients_table").DataTable({
-                "processing": true,
-                "serverSide": true,
-		"fnDrawCallback": function( oSettings ) {
-		    wireUpFormsButtons();
-                },
-                ajax: {
+            var load_contexts_list;
+            var context_list;
+            {% if columns %}
+                context_list = $("#patients_table").DataTable({
+                    "processing": true,
+                    "serverSide": true,
+                    "fnDrawCallback": function (oSettings) {
+                        wireUpFormsButtons();
+                    },
+                    ajax: {
                         url: getApiUrl(registryCode, getDrawLength()),
                         dataSrc: "rows",
                         type: "POST"
-                },
-                columns: {{columns|safe}}
-            }).on("draw", function () {
-                $("#loading_text").hide();
-                $('button[data-toggle=popover]').popover({
-                    'html': true,
-                    'title': '',
-                    'trigger': 'click',
-                    'placement': 'bottom',
-                    'container': 'body'
-                });
-            });
-            load_contexts_list = function(apiUrl) {
-              if (context_list) {
-                  context_list.ajax.url(apiUrl).load();
-              }
-            }
-        {% else %}
-            load_contexts_list = function() { $("#loading_text").hide(); }
-        {% endif %}
-
-        $("#registry_options").change(function () {
-            $("#loading_text").show();
-            var registryCode= $("#registry_options > option:selected").attr("id");
-            var apiUrl = getApiUrl(registryCode, getDrawLength());
-            load_contexts_list(apiUrl);
-	    wireUpFormsButtons();
-        });
-
-
-        $("#add_patient").click(function () {
-            var registryCode = null;
-            var addPatientUrl = '{% url "patient_add" "xxx" %}';
-            try {
-                registryCode = $("#registry_options option:selected").attr('id');
-                if (registryCode == "---") {
-                    alert("Please select registry first");
-                    return;
+                    },
+                    columns: {{columns|safe }}
+                    }).on("draw", function () {
+                        $("#loading_text").hide();
+                        $('button[data-toggle=popover]').popover({
+                            'html': true,
+                            'title': '',
+                            'trigger': 'click',
+                            'placement': 'bottom',
+                            'container': 'body'
+                        });
+                    });
+                load_contexts_list = function (apiUrl) {
+                    if (context_list) {
+                        context_list.ajax.url(apiUrl).load();
+                    }
                 }
+            {% else %}
+                load_contexts_list = function () { $("#loading_text").hide(); }
+            {% endif %}
 
-                if (registryCode == undefined) {
+            $("#registry_options").change(function () {
+                $("#loading_text").show();
+                var registryCode = $("#registry_options > option:selected").attr("id");
+                var apiUrl = getApiUrl(registryCode, getDrawLength());
+                load_contexts_list(apiUrl);
+                wireUpFormsButtons();
+            });
+
+
+            $("#add_patient").click(function () {
+                var registryCode = null;
+                var addPatientUrl = '{% url "patient_add" "xxx" %}';
+                try {
+                    registryCode = $("#registry_options option:selected").attr('id');
+                    if (registryCode == "---") {
+                        alert("Please select registry first");
+                        return;
+                    }
+
+                    if (registryCode == undefined) {
+                        registryCode = "{{registries.0.code}}";
+                    }
+                } catch (err) {
+                    // one registry ?
                     registryCode = "{{registries.0.code}}";
                 }
-            } catch (err) {
-                // one registry ?
-                registryCode = "{{registries.0.code}}";
-            }
-            var location = addPatientUrl.replace("xxx", registryCode);
-            window.location.replace(location);
-        });
+                var location = addPatientUrl.replace("xxx", registryCode);
+                window.location.replace(location);
+            });
 
-
-        $("#registry_options").trigger("change");
-
+            $("#registry_options").trigger("change");
 
         });
-
-
-
     </script>
 {% endblock %}
 

--- a/rdrf/rdrf/templates/rdrf_cdes/patients_listing.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/patients_listing.html
@@ -10,6 +10,7 @@
      <script type="text/javascript" src="{% static 'datatables-1.10.12/js/jquery.dataTables.min.js' %}"></script>
 
     <script>
+
         $(document).ready(function() {
 
         $.fn.dataTable.ext.errMode = 'throw';
@@ -30,6 +31,35 @@
                     var csrfToken = '{{ csrf_token }}';
                     xhr.setRequestHeader('X-CSRFToken', csrfToken);
         }});
+
+        function wireUpFormsButtons() {
+
+	    $(".patient-forms-button").click(function() {
+		var button = $(this);
+		var registryCode = getSelectedRegistry();
+
+		function showFormsList(html) {
+		    var ul = button.parent().find("ul.dropdown-menu");
+		    if(html.indexOf("<li>") == -1) html = "<li>No Data</li>";
+		    $(ul).html(html);
+		}
+	    
+		var patientId = parseInt(button.data("patient"));
+		var formGroupId = parseInt(button.data("formgroup"));
+
+		rpc.send("get_forms_list", [registryCode, patientId, formGroupId], function(response) {
+                if (response.status == "fail") {
+		    alert(response.error);
+		    
+	    } else {
+		var html= response.result.html;
+		showFormsList(html);
+	    }
+	    });
+	
+
+	  });
+	}
 
         function getDrawLength() {
             try {
@@ -81,7 +111,9 @@
             context_list = $("#patients_table").DataTable({
                 "processing": true,
                 "serverSide": true,
-                //"sAjaxDataProp" : "data",
+		"fnDrawCallback": function( oSettings ) {
+		    wireUpFormsButtons();
+                },
                 ajax: {
                         url: getApiUrl(registryCode, getDrawLength()),
                         dataSrc: "rows",
@@ -112,6 +144,7 @@
             var registryCode= $("#registry_options > option:selected").attr("id");
             var apiUrl = getApiUrl(registryCode, getDrawLength());
             load_contexts_list(apiUrl);
+	    wireUpFormsButtons();
         });
 
 

--- a/rdrf/rdrf/templates/rdrf_cdes/patients_listing.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/patients_listing.html
@@ -48,16 +48,14 @@
 		var formGroupId = parseInt(button.data("formgroup"));
 
 		rpc.send("get_forms_list", [registryCode, patientId, formGroupId], function(response) {
-                if (response.status == "fail") {
-		    alert(response.error);
-		    
-	    } else {
-		var html= response.result.html;
-		showFormsList(html);
-	    }
-	    });
-	
-
+                    if (response.status != "fail") {
+	                var status = response.result.status;
+	                if (status == "success") {
+	                   var html= response.result.html;
+	                   showFormsList(html);
+	                }
+	            }
+	        });
 	  });
 	}
 


### PR DESCRIPTION
Current patient listing is very slow ( most noticeably in FH). The main cause is the retrieval of the forms list dropdown for each patient on the page. I have moved this logic into an ajax call so the forms list is rendered on demand. This has reduced  the page load time by a factor 11-12 in my testing with a db of 50000 dummy patients.

The forms list itself has been enhanced slightly: Currenly for FH, say, all folllow ups are shown in a list. The new implementation shows the latest 10. Also an "Add Follow Up" link has been appended to the list allowing easy updating of a patient record resulting from a search. I've toned down the colour to make it less garish also. 


