### PR TITLE
mtm #281 form progress when there are patient_types

### DIFF
--- a/rdrf/rdrf/views/patients_listing.py
+++ b/rdrf/rdrf/views/patients_listing.py
@@ -279,6 +279,7 @@ class PatientsListingView(View):
         # we need to do this so that the progress data for this instance
         # loaded!
         self.form_progress.reset()
+        self.form_progress._set_current(instance)
         return {
             col.field: col.fmt(
                 col.cell(


### PR DESCRIPTION
Form progress is a notion we introduced trying to emulate some ophg requirements.

Forms have "completion cdes"  - which affect the percentages for form progress - but we didn't modify the calculation when we introduced the notion of "patient type" for MTM. This ticket addresses this.