### PR TITLE
rdrf #590 added django reversion on ClinicalData model

### DIFF
--- a/rdrf/rdrf/admin.py
+++ b/rdrf/rdrf/admin.py
@@ -20,12 +20,13 @@ from rdrf.models.definition.models import ContextFormGroup
 from rdrf.models.definition.models import ContextFormGroupItem
 from rdrf.models.definition.models import CDEFile
 from rdrf.models.definition.models import ConsentRule
+from rdrf.models.definition.models import ClinicalData
 from rdrf.models.proms.models import Survey
 from rdrf.models.proms.models import SurveyQuestion
 from rdrf.models.proms.models import Precondition
 from rdrf.models.proms.models import SurveyAssignment
 
-
+from reversion.admin import VersionAdmin
 
 import logging
 from django.http import HttpResponse
@@ -44,6 +45,9 @@ from functools import reduce
 
 logger = logging.getLogger(__name__)
 
+@admin.register(ClinicalData)
+class BaseReversionAdmin(VersionAdmin):
+    pass
 
 class SectionAdmin(admin.ModelAdmin):
     list_display = ('code', 'display_name')

--- a/rdrf/rdrf/admin.py
+++ b/rdrf/rdrf/admin.py
@@ -372,7 +372,7 @@ class ConsentRuleAdmin(admin.ModelAdmin):
 
 class PreconditionAdmin(admin.ModelAdmin):
     model = Precondition
-    list_display = ('survey','cde','value')
+    list_display = ('survey', 'cde', 'value')
 
 class SurveyQuestionAdmin(admin.StackedInline):
     model = SurveyQuestion
@@ -388,10 +388,7 @@ class SurveyAdmin(admin.ModelAdmin):
 
 class SurveyAssignmentAdmin(admin.ModelAdmin):
     model = SurveyAssignment
-    list_display = ("registry", "survey_name","patient_token", "state","created","updated", "response") 
-
-
-    
+    list_display = ("registry", "survey_name", "patient_token", "state", "created", "updated", "response")
 
 
 if settings.DESIGN_MODE:

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -183,6 +183,7 @@ INSTALLED_APPS = [
     'registry.common',
     'registry.genetic',
     'registration',
+    'reversion',
     'storages',
     'django_cron',
     'django_otp',

--- a/rdrf/setup.py
+++ b/rdrf/setup.py
@@ -47,6 +47,7 @@ requirements = [
     "django-two-factor-auth==1.6.2",
     "phonenumberslite==8.8.1",
     "qrcode==4.0.4",
+    "django-reversion",
 ]
 
 

--- a/rdrf/setup.py
+++ b/rdrf/setup.py
@@ -47,7 +47,7 @@ requirements = [
     "django-two-factor-auth==1.6.2",
     "phonenumberslite==8.8.1",
     "qrcode==4.0.4",
-    "django-reversion",
+    "django-reversion==3.0.0",
 ]
 
 


### PR DESCRIPTION
Adding reversion module in our application.
Apply reversion on ClinicalData model so that the model can have history of changes. This enables the Admin user to revert back to any older version.
The reversion for ClinicalData is applied at Admin level.