### PR TITLE
copyright text for Proms system

### DIFF
--- a/rdrf/rdrf/templates/proms/preamble.html
+++ b/rdrf/rdrf/templates/proms/preamble.html
@@ -43,6 +43,15 @@
             </div>
         </div>
     </div>
+    <div id="footer">
+        <div class="container">
+            <br />
+            <br />
+            <br />
+            <h5 class="text-center"><b>COPYRIGHT NOTICE</b></h5>
+            <h5 class="text-muted text-center"><i>{{copyright_text}}</i></h5>
+        </div>
+    </div>
 </body>
 
 </html>

--- a/rdrf/rdrf/views/proms_views.py
+++ b/rdrf/rdrf/views/proms_views.py
@@ -94,8 +94,10 @@ class PromsLandingPageView(View):
                                               state=SurveyStates.REQUESTED)
         survey_display_name = survey_assignment.survey.display_name
         preamble_text = registry_model.metadata.get("preamble_text")
+        copyright_text = registry_model.metadata.get("copyright_text")
         context = {
             "preamble_text": preamble_text,
+            "copyright_text": copyright_text,
             "survey_name": survey_display_name
         }
         return render(request, "proms/preamble.html", context)


### PR DESCRIPTION
- Adding copyright text at the PROMS survey page under the Begin Survey button
- Copyright text is set at the metadata of the registry as "copyright_text"