### PR TITLE
#836 ReadOnlySelect widget was broken by last Django update

### DIFF
--- a/rdrf/rdrf/forms/widgets/widgets.py
+++ b/rdrf/rdrf/forms/widgets/widgets.py
@@ -379,7 +379,7 @@ class ReadOnlySelect(widgets.Select):
     def _make_label(self, html):
         import re
         html = html.replace("\n", "")
-        pattern = re.compile(r'.*selected=\"selected\">(.*?)</option>.*')
+        pattern = re.compile(r'.*selected>(.*?)</option>.*')
         m = pattern.match(html)
         if m:
             option_display_text = m.groups(1)[0]


### PR DESCRIPTION
A regular expression were looking for selected="selected" in order
to replace the select by a label. However, as mentioned in Django doc,
boolean selected is prefered HTML5 compare to selected="selected".
I am guessing Django changed the Select widget html in the latest 2.1 version.