### PR TITLE
#846 fix the reset password link

### DIFF
--- a/rdrf/registry/groups/admin_forms.py
+++ b/rdrf/registry/groups/admin_forms.py
@@ -113,6 +113,9 @@ class UserChangeForm(UserValidationMixin, forms.ModelForm):
                 id__in=[wg.id for wg in self.user.working_groups.all()])
             self.fields['registry'].queryset = Registry.objects.filter(
                 code__in=[reg.code for reg in self.user.registry.all()])
+        password = self.fields.get('password')
+        if password:
+            password.help_text = password.help_text.format('../password/')
 
     from django.contrib.auth.forms import UserChangeForm as OldUserChangeForm
     password = ReadOnlyPasswordHashField(


### PR DESCRIPTION
Note there are two issues:
* first the class UserChangeForm is  replacing the base Django UserChangeForm class
in order to add support for workinggroups and registry fields. If at the time of the
decision it was ok, since Django likely updated the Django UserChangeForm and so we
are losing the new code from Django. Probably introducing other bug (.i.e some code is
related to user permission in the Django UserChangeForm). An alternative solution is likely to extend
the base function instead to override it.
* the password reset page has the default Django UI theme - I guess it has always been the
case.