### PR TITLE
#861 update proms consent checkbox confirmation text

### DIFF
--- a/rdrf/rdrf/frontend/src/pages/proms_page/components/question.tsx
+++ b/rdrf/rdrf/frontend/src/pages/proms_page/components/question.tsx
@@ -97,9 +97,13 @@ class Question extends React.Component<QuestionInterface, object> {
         const pStyle = {color: "white", align: "center"};
         const style = { width: "50%", height:"50vh", margin:"0 auto", leftPadding: "100px" };
         const isLast = (this.props.questions.length - 1) === this.props.stage;
-	const isConsent = question.cde === "PROMSConsent";
-        const consentText = "I consent to ongoing involvement in the CIC Cancer project" +
-            "and receiving a reminder for the next survey.";
+	    const isConsent = question.cde === "PROMSConsent";
+        const consentText = <div>By ticking this box you:
+                                <ul>
+                                    <li>Give consent for the information you provide to be used for the CIC Cancer project; and </li>
+                                    <li>Will receive a reminder when the next survey is due.</li>
+                                </ul>
+                            </div>;
 
         return (
             <Form>

--- a/rdrf/rdrf/models/proms/models.py
+++ b/rdrf/rdrf/models/proms/models.py
@@ -15,6 +15,8 @@ from rdrf.helpers.utils import generate_token
 
 
 def clean(s):
+    if s is None:
+        return ""
     return s.replace("'", "").replace('"', "")
 
 


### PR DESCRIPTION
Note: we also fixed a bug with the survey question clean() function crashing when the instructions
were empty.