### PR TITLE
issue #897 - update_calculated_fields crashes on unexisting key

### DIFF
--- a/rdrf/rdrf/db/dynamic_data.py
+++ b/rdrf/rdrf/db/dynamic_data.py
@@ -4,6 +4,8 @@ from itertools import zip_longest
 import logging
 from django.core.files.uploadedfile import InMemoryUploadedFile
 
+from rdrf.helpers.utils import BadKeyError
+
 from rdrf.db import filestorage
 from rdrf.forms.file_upload import FileUpload, wrap_fs_data_for_form
 from rdrf.models.definition.models import Registry, ClinicalData
@@ -169,7 +171,8 @@ def parse_form_data(registry,
                     existing_record=None,
                     is_multisection=False,
                     parse_all_forms=False,
-                    django_instance=None):
+                    django_instance=None,
+                    skip_bad_key=False):
     """
     This class takes a bag of values with keys like:
     Takes a bag of values with keys like:
@@ -180,7 +183,7 @@ def parse_form_data(registry,
     This is more or less the opposite of `build_form_data`.
     """
     return FormDataParser(registry, form, data, existing_record, is_multisection, parse_all_forms,
-                          django_instance).nested_data
+                          django_instance, skip_bad_key).nested_data
 
 
 class FormDataParser(object):
@@ -199,7 +202,8 @@ class FormDataParser(object):
                  existing_record=None,
                  is_multisection=False,
                  parse_all_forms=False,
-                 django_instance=None):
+                 django_instance=None,
+                 skip_bad_key=False):
         self.registry_model = registry_model
         self.form_data = form_data
         self.parsed_data = {}
@@ -213,6 +217,7 @@ class FormDataParser(object):
         self.custom_consents = None
         self.address_data = None
         self.parse_all_forms = parse_all_forms
+        self.skip_bad_key = skip_bad_key
 
         if django_instance:
             self.django_id = django_instance.pk
@@ -373,7 +378,13 @@ class FormDataParser(object):
                 elif key == "PatientDataAddressSection":
                     self.address_data = self.form_data[key]
                 elif is_delimited_key(key):
-                    form_model, section_model, cde_model = models_from_mongo_key(self.registry_model, key)
+                    if self.skip_bad_key is True:
+                        try:
+                            form_model, section_model, cde_model = models_from_mongo_key(self.registry_model, key)
+                        except BadKeyError:
+                            logger.debug(f"Skipping key: {key}")
+                    else:
+                        form_model, section_model, cde_model = models_from_mongo_key(self.registry_model, key)
                     value = self.form_data[key]
                     self.parsed_data[(form_model, section_model, cde_model)] = self._parse_value(value)
         else:
@@ -681,7 +692,8 @@ class DynamicDataWrapper(object):
                           multisection=False,
                           parse_all_forms=False,
                           index_map=None,
-                          additional_data=None):
+                          additional_data=None,
+                          skip_bad_key=False):
         self._convert_date_to_datetime(form_data)
 
         if self.CREATE_MODE:
@@ -708,7 +720,8 @@ class DynamicDataWrapper(object):
             existing_record=record.data,
             is_multisection=multisection,
             parse_all_forms=parse_all_forms,
-            django_instance=self.obj)
+            django_instance=self.obj,
+            skip_bad_key=skip_bad_key)
 
         if additional_data is not None:
             nested_data.update(additional_data)

--- a/rdrf/rdrf/management/commands/update_calculated_fields.py
+++ b/rdrf/rdrf/management/commands/update_calculated_fields.py
@@ -160,7 +160,7 @@ def save_new_calculation(changed_calculated_cdes, context_id, form_name, patient
     # save the new form values in the ClinicalData model only when we have one values
     context_model = RDRFContext.objects.get(id=context_id)
     if changed_calculated_cdes:
-        logger.info(f"UPDATING DB: These are the new value of the form/context {changed_calculated_cdes} - patient: {patient_model.id} - context: {context_id}")
+        logger.info(f"UPDATING DB: These are the new value of the form/context {changed_calculated_cdes} - registry: {registry_model.code} - patient: {patient_model.id} - form: {form_name} - context: {context_id}")
         for changed_calculated_cde_code in changed_calculated_cdes.keys():
             patient_model.set_form_value(registry_code=registry_model.code,
                                          form_name=form_name,
@@ -171,7 +171,8 @@ def save_new_calculation(changed_calculated_cdes, context_id, form_name, patient
                                          save_snapshot=list(changed_calculated_cdes.keys())[
                                              -1] == changed_calculated_cde_code,
                                          user=ScriptUser(),
-                                         context_model=context_model)
+                                         context_model=context_model,
+                                         skip_bad_key=True)
 
 
 def context_ids_for_patient_and_form(patient_model, form_name, registry_model):

--- a/rdrf/registry/patients/models.py
+++ b/rdrf/registry/patients/models.py
@@ -595,7 +595,9 @@ class Patient(models.Model):
             value,
             context_model=None,
             save_snapshot=False,
-            user=None):
+            user=None,
+            skip_bad_key=False):
+
         from rdrf.db.dynamic_data import DynamicDataWrapper
         from rdrf.helpers.utils import mongo_key
         from rdrf.forms.progress.form_progress import FormProgress
@@ -629,7 +631,7 @@ class Patient(models.Model):
         else:
             mongo_data[key] = value
             mongo_data[timestamp] = t
-            wrapper.save_dynamic_data(registry_code, "cdes", mongo_data)
+            wrapper.save_dynamic_data(registry_code, "cdes", mongo_data, skip_bad_key=skip_bad_key)
 
         # update form progress
         registry_model = Registry.objects.get(code=registry_code)


### PR DESCRIPTION
Problem: the django admin update_Calculated_fields is crashing on staging as
it is calling save_form_value which load all dynamic data and save them all.
The problem been that some key (form__section_cdecode) do not exist, the form name
having changed. When saving the dynamic data, it crashes as the key does not exist.
To solve the issue we add a new parameter ignoring the not existing keys.