### PR TITLE
#852 do not send secret token in the header

### DIFF
--- a/rdrf/rdrf/models/proms/models.py
+++ b/rdrf/rdrf/models/proms/models.py
@@ -333,11 +333,9 @@ class SurveyRequest(models.Model):
         logger.debug("api_url = %s" % api_url)
 
         survey_assignment_data = self._get_survey_assignment_data()
-        headers = {'PROMS_SECRET_TOKEN': settings.PROMS_SECRET_TOKEN}
+        survey_assignment_data = {**survey_assignment_data, 'proms_secret_token': settings.PROMS_SECRET_TOKEN}
 
-        response = requests.post(api_url,
-                                 data=survey_assignment_data,
-                                 headers=headers)
+        response = requests.post(api_url, data=survey_assignment_data)
         logger.debug("response code %s" % response.status_code)
         self.check_response_for_error(response)
         logger.debug("posted data")

--- a/rdrf/rdrf/services/rest/auth.py
+++ b/rdrf/rdrf/services/rest/auth.py
@@ -7,24 +7,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_token(request, token):
-    logger.info("proms auth getting token %s ..." % token)
-    if token not in request.META:
-        logger.info("%s not in request - returning None" % token)
-        return None
-    else:
-        token_value = request.META.get(token)
-        logger.info("%s = %s" % (token, token_value))
-        return token_value
-
-
 class PromsAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request):
         logger.info("authenticating proms")
         from django.conf import settings
-        secret_token = get_token(request, 'HTTP_PROMS_SECRET_TOKEN')
-        if secret_token is None:
-            secret_token = get_token(request, 'PROMS_SECRET_TOKEN')
+        secret_token = request.POST.get("proms_secret_token", "")
 
         logger.info("token from request: %s" % secret_token)
         proms_secret_token = settings.PROMS_SECRET_TOKEN
@@ -34,7 +21,7 @@ class PromsAuthentication(authentication.BaseAuthentication):
 
         if secret_token != proms_secret_token:
             logger.info("tokens don't match - failed to auth")
-            return None
+            return False
 
         try:
             user = CustomUser.objects.get(username=proms_username)

--- a/rdrf/rdrf/services/rest/views/proms_api.py
+++ b/rdrf/rdrf/services/rest/views/proms_api.py
@@ -115,13 +115,12 @@ class PromsProcessor:
         api = "/api/proms/v1/promsdownload"
 
         api_url = self.proms_url + api
-        headers = {'PROMS_SECRET_TOKEN': settings.PROMS_SECRET_TOKEN}
         logger.debug("making request to %s" % api_url)
-
-        response = requests.post(api_url,
-                                 headers=headers)
+        post_data = {'proms_secret_token': settings.PROMS_SECRET_TOKEN}
+        response = requests.post(api_url, data=post_data)
 
         if response.status_code != 200:
+            logger.info(f"Error retrieving proms")
             raise Exception("Error retrieving proms")
         else:
             logger.debug("got proms data from proms system OK")


### PR DESCRIPTION
Nginx was eating the custom header secret token. We don't want to
depend from Nginx configuration (neither Nginx configuration mention the
secret_token existence) so we will sent the secret token through
the POST variable..