### PR TITLE
#932 pull_proms: sort by updated date to avoid overwriting the most recently answered 

### DIFF
--- a/rdrf/rdrf/services/rest/views/proms_api.py
+++ b/rdrf/rdrf/services/rest/views/proms_api.py
@@ -110,7 +110,9 @@ class PromsDownload(APIView):
         return response
 
     def get_queryset(self, registry_code):
-        return SurveyAssignment.objects.filter(state="completed", registry__code=registry_code)
+        # we order the survey by updated date so the last answered survey will overwrite previous answered survey
+        # (in case there are multiple answers for the same survey/patient)
+        return SurveyAssignment.objects.filter(state="completed", registry__code=registry_code).order_by('updated')
 
 
 class PromsProcessor:


### PR DESCRIPTION
for example, an admin creates two surveys and send the two links. But the second survey is answered first (as the user will read it first), then the user answers the first survey link. Obviously we want to keep the latest answered survey. So we need to sort by updated time.