### PR TITLE
# 901 switch from yaml.load to yaml.safe_load (for none complex python object)

### DIFF
--- a/rdrf/rdrf/management/commands/check_structure.py
+++ b/rdrf/rdrf/management/commands/check_structure.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
 
         if os.path.exists(schema_path):
             with open(schema_path) as sf:
-                return yaml.load(sf)
+                return yaml.safe_load(sf)
 
         raise FileNotFoundError(errno.ENOENT,
                                 os.strerror(errno.ENOENT),

--- a/rdrf/rdrf/management/commands/create_translation_file.py
+++ b/rdrf/rdrf/management/commands/create_translation_file.py
@@ -119,7 +119,7 @@ class Command(BaseCommand):
     def _load_yaml_file(self, file_name):
         with open(file_name, encoding='utf-8') as f:
             try:
-                self.data = yaml.load(f)
+                self.data = yaml.safe_load(f)
             except Exception as ex:
                 print("could not load yaml file %s: %s" % (file_name,
                                                            ex))

--- a/rdrf/rdrf/models/definition/models.py
+++ b/rdrf/rdrf/models/definition/models.py
@@ -1912,7 +1912,7 @@ class ClinicalData(models.Model):
         if not self.modjgo_schema:
             try:
                 with open(self.modjgo_schema_file) as f:
-                    self.modjgo_schema = yaml.load(f.read())
+                    self.modjgo_schema = yaml.safe_load(f.read())
             except BaseException:
                 logger.exception("Error reading %s" % self.modjgo_schema_file)
 

--- a/rdrf/rdrf/scripts/data_dictionary_generator.py
+++ b/rdrf/rdrf/scripts/data_dictionary_generator.py
@@ -279,7 +279,7 @@ output_file = sys.argv[2]
 
 
 with open(yaml_file) as yf:
-    data = yaml.load(yf)
+    data = yaml.safe_load(yf)
 
 f = codecs.open(output_file, mode="w", encoding="utf-8")
 ddr = DataDefinitionReport(data, f)

--- a/rdrf/rdrf/services/io/defs/importer.py
+++ b/rdrf/rdrf/services/io/defs/importer.py
@@ -92,7 +92,7 @@ class Importer(object):
 
     def load_yaml_from_string(self, yaml_string):
         self.yaml_data_file = "yaml string"
-        self.data = yaml.load(yaml_string)
+        self.data = yaml.safe_load(yaml_string)
         self.state = ImportState.LOADED
 
     def load_yaml(self, yaml_data_file):

--- a/rdrf/rdrf/testing/unit/tests.py
+++ b/rdrf/rdrf/testing/unit/tests.py
@@ -459,7 +459,7 @@ class ExporterTestCase(RDRFTestCase):
             f.write(yaml_data)
 
         with open("/tmp/test.yaml") as f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
 
         test_key('EXPORT_TYPE', data)
         test_key('RDRF_VERSION', data)

--- a/rdrf/rdrf/views/migration_view.py
+++ b/rdrf/rdrf/views/migration_view.py
@@ -16,7 +16,7 @@ class MigrationView(View):
         sma_rdrf = None
 
         if request.FILES:
-            sma_rdrf = yaml.load(request.FILES['rdrf_yaml'].read())
+            sma_rdrf = yaml.safe_load(request.FILES['rdrf_yaml'].read())
             sma_legacy = json.loads(request.FILES['legacy_json'].read())
             self.rdrf_legacy = sma_legacy
 

--- a/scripts/check_yaml_cde_calculation.py
+++ b/scripts/check_yaml_cde_calculation.py
@@ -22,7 +22,7 @@ def main():
 
 def check_file(filename):
     num_errors = 0
-    data = yaml.load(io.open(filename, errors="replace"))
+    data = yaml.safe_load(io.open(filename, errors="replace"))
     for cde in data.get("cdes") or []:
         calc = cde.get("calculation")
         if calc:

--- a/scripts/old/yaml2excel.py
+++ b/scripts/old/yaml2excel.py
@@ -258,6 +258,6 @@ if __name__ == "__main__":
     excludes = args.exclude.split(",")
     print("excludes = %s" % excludes)
     with open(args.yaml_file) as f:
-        data = yaml.load(f)
+        data = yaml.safe_load(f)
     spreadsheet = SpreadSheetCreator(data, args.output_file, args.nrows, excludes=excludes)
     spreadsheet.create()


### PR DESCRIPTION
What has not been changed (because it would likely require a rewrite as it uses complex yaml file):

importer.py
def load_yaml(self, yaml_data_file):

run_yaml_cde_calculation_tests.py
def load_yaml(file_obj):