### PR TITLE
#959 ignore is_parent for anything else than angelman

### DIFF
--- a/rdrf/rdrf/testing/unit/tests.py
+++ b/rdrf/rdrf/testing/unit/tests.py
@@ -1573,10 +1573,17 @@ class RemindersTestCase(TestCase):
         assert result == "testuser\n", "Expected testuser instead got [%s]" % result
 
         # parents are detected
-        self._setup_user("testuser", Time.LONG_AGO, group="parents")
-        result = self._run_command(registry_code="foobar", days=365)
-        assert result == "testuser\n", "Expected testuser instead got [%s]" % result
-
+        parent_feature = True
+        # Check parent feature is enabled.
+        try:
+            __import__('angelman.parent_view')
+        except ImportError:
+            parent_feature = False
+        if parent_feature:
+            self._setup_user("testuser", Time.LONG_AGO, group="parents")
+            result = self._run_command(registry_code="foobar", days=365)
+            assert result == "testuser\n", "Expected testuser instead got [%s]" % result
+        
         # but not other types of users
         self._setup_user("testuser", Time.LONG_AGO, group="curators")
         result = self._run_command(registry_code="foobar", days=365)

--- a/rdrf/rdrf/testing/unit/tests.py
+++ b/rdrf/rdrf/testing/unit/tests.py
@@ -1583,7 +1583,7 @@ class RemindersTestCase(TestCase):
             self._setup_user("testuser", Time.LONG_AGO, group="parents")
             result = self._run_command(registry_code="foobar", days=365)
             assert result == "testuser\n", "Expected testuser instead got [%s]" % result
-        
+
         # but not other types of users
         self._setup_user("testuser", Time.LONG_AGO, group="curators")
         result = self._run_command(registry_code="foobar", days=365)

--- a/rdrf/registry/groups/models.py
+++ b/rdrf/registry/groups/models.py
@@ -137,6 +137,14 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
 
     @property
     def is_parent(self):
+        # Check that the parent feature is available.
+        # This is currently a hardcoded angelman check.
+        # Checking import has a low performance impact.
+        # 50ms the is_parent() first call, 3ms the following calls.
+        try:
+            __import__('angelman.parent_view')
+        except ImportError:
+            return False
         return self.in_group(RDRF_GROUPS.PARENT)
 
     @property


### PR DESCRIPTION
This fix is a little between two chairs:
- it works by checking if the parent_view module exists which I think is an ok check.
- however it hardcodes angleman module location because the parent_view module is in the angelman part, not in rdrf.

PS: tested on rdrf and Angelman. On Angelman the parent login unit test is executed and the is_parent() function is executed too.