### PR TITLE
#976 explorer: harden reporting interface

### DIFF
--- a/rdrf/explorer/models.py
+++ b/rdrf/explorer/models.py
@@ -9,7 +9,7 @@ from rdrf.models.definition.models import RegistryForm
 from rdrf.models.definition.models import RDRFContext
 from rdrf.models.definition.models import Section
 from rdrf.models.definition.models import CommonDataElement
-from rdrf.helpers.utils import parse_iso_date
+from rdrf.helpers.utils import parse_iso_date, check_suspicious_sql
 from registry.patients.models import Patient
 import json
 
@@ -287,6 +287,12 @@ class Query(models.Model):
             if len(errors) > 0:
                 error_string = ",".join(errors)
                 raise ValidationError("Report Config Errors: %s" % error_string)
+
+        # Check for dangereous sql queries.
+        securityerrors = check_suspicious_sql(self.sql_query, 'unknown')
+        if securityerrors:
+            error_msg = ' | '.join(securityerrors)
+            raise ValidationError(f"{error_msg}")
 
     def _get_mixed_query_errors(self):
         import json

--- a/rdrf/explorer/models.py
+++ b/rdrf/explorer/models.py
@@ -289,7 +289,7 @@ class Query(models.Model):
                 raise ValidationError("Report Config Errors: %s" % error_string)
 
         # Check for dangereous sql queries.
-        securityerrors = check_suspicious_sql(self.sql_query, 'unknown')
+        securityerrors = check_suspicious_sql(self.sql_query, self.created_by)
         if securityerrors:
             error_msg = ' | '.join(securityerrors)
             raise ValidationError(f"{error_msg}")

--- a/rdrf/rdrf/helpers/utils.py
+++ b/rdrf/rdrf/helpers/utils.py
@@ -884,16 +884,16 @@ def get_verification_status(patient_model,
     return None
 
 
-def check_suspicious_sql(sql_query, userid):
+def check_suspicious_sql(sql_query, user):
     # Checker for SQL explorer.
     # Return error messages in an list if anything suspicious is identified in the SQL.
 
     sql_query_lowercase = ' '.join(sql_query.lower().split())
     securityerrors = []
     if not sql_query_lowercase.startswith("select p.id"):
-        logger.warning(f"User id {userid} try to write/validate a SQL request not starting by SELECT p.id: {sql_query_lowercase}")
+        logger.warning(f"User {user} tries to write/validate a SQL request not starting by SELECT p.id: {sql_query_lowercase}")
         securityerrors.append("The SQL query must start with SELECT p.id")
     if any(sql_command in sql_query_lowercase for sql_command in ["drop", "union", "update"]):
-        logger.warning(f"User id {userid} try to write/validate a suspicious SQL request containing DROP, UNION or UPDATE: {sql_query_lowercase}")
+        logger.warning(f"User {user} tries to write/validate a suspicious SQL request containing DROP, UNION or UPDATE: {sql_query_lowercase}")
         securityerrors.append("The SQL query must not contain any of these keywords: DROP, UNION, UPDATE")
     return securityerrors

--- a/rdrf/rdrf/helpers/utils.py
+++ b/rdrf/rdrf/helpers/utils.py
@@ -882,3 +882,18 @@ def get_verification_status(patient_model,
                 # verified
                 return "V"
     return None
+
+
+def check_suspicious_sql(sql_query, userid):
+    # Checker for SQL explorer.
+    # Return error messages in an list if anything suspicious is identified in the SQL.
+
+    sql_query_lowercase = ' '.join(sql_query.lower().split())
+    securityerrors = []
+    if not sql_query_lowercase.startswith("select p.id"):
+        logger.warning(f"User id {userid} try to write/validate a SQL request not starting by SELECT p.id: {sql_query_lowercase}")
+        securityerrors.append("The SQL query must start with SELECT p.id")
+    if any(sql_command in sql_query_lowercase for sql_command in ["drop", "union", "update"]):
+        logger.warning(f"User id {userid} try to write/validate a suspicious SQL request containing DROP, UNION or UPDATE: {sql_query_lowercase}")
+        securityerrors.append("The SQL query must not contain any of these keywords: DROP, UNION, UPDATE")
+    return securityerrors


### PR DESCRIPTION
all queries must start with: "SELECT p.id" ( this is required to make the report work anyway)
"UNION " must not be in the clause
"UPDATE " must not be the clause
"DROP " must not be in the clause