### PR TITLE
#1062 registration: fix api call to get subdivision

### DIFF
--- a/rdrf/rdrf/services/rest/views/api_views.py
+++ b/rdrf/rdrf/services/rest/views/api_views.py
@@ -170,8 +170,12 @@ class ListStates(APIView):
 
     def get(self, request, country_code, format=None):
         try:
-            states = sorted(pycountry.subdivisions.get(
-                country_code=country_code), key=lambda x: x.name)
+            subdivisions = pycountry.subdivisions.get(
+                country_code=country_code)
+            if subdivisions:
+                states = sorted(subdivisions, key=lambda x: x.name)
+            else:
+                states = []
         except KeyError:
             # For now returning empty list because the old api view was doing the same
             # raise BadRequestError("Invalid country code '%s'" % country_code)


### PR DESCRIPTION
The API call was crashing when the user sent a wrong country code (XX). We were receiving notification.

Note: we could not identified why the user sent wrong XX country code. We suspect that the user, using the Chrome 42 Android 6.0 (Nexus 5S), has an obsolete javascript engine behaving weirdly.