### PR TITLE
#1110 auto build of Proms JS/CSS file in dev environment

### DIFF
--- a/rdrf/rdrf/frontend/package.json
+++ b/rdrf/rdrf/frontend/package.json
@@ -60,6 +60,7 @@
     ]
   },
   "devDependencies": {
+    "fs": "^0.0.1-security",
     "renamer": "^1.1.3",
     "tslint": "^5.20.0",
     "tslint-config-prettier": "^1.18.0",

--- a/rdrf/rdrf/frontend/watch.js
+++ b/rdrf/rdrf/frontend/watch.js
@@ -5,6 +5,7 @@
 
 const watch = require('watch');
 const { exec } = require('child_process');
+const fs = require('fs')
 
 function run_yarn_build() {
     exec('yarn build', (err, stdout, stderr) => {
@@ -38,4 +39,20 @@ watch.watchTree('./src', function (f, curr, prev) {
         run_yarn_build()
     }
 })
+
+// do a first build if a file is missing.
+try {
+    if (fs.existsSync('../static/proms/js/main-bundle.min.js') &&
+        fs.existsSync('../static/proms/js/vendors-bundle.min.js') &&
+        fs.existsSync('../static/proms/js/runtime-bundle.min.js') &&
+        fs.existsSync('../static/proms/css/main.css') &&
+        fs.existsSync('../static/proms/css/vendors.css')) {
+        console.log('JS and CSS Proms files already build')
+    } else {
+        console.log('Building JS/CSS Proms files.')
+        run_yarn_build()
+    }
+} catch (err) {
+    console.log(err)
+}
 

--- a/rdrf/rdrf/frontend/yarn.lock
+++ b/rdrf/rdrf/frontend/yarn.lock
@@ -4455,6 +4455,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fs@^0.0.1-security:
+  version "0.0.1-security"
+  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
+  integrity sha1-invTcYa23d84E/I4WLV+yq9eQdQ=
+
 fsevents@2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.0.7.tgz#382c9b443c6cbac4c57187cdda23aa3bf1ccfc2a"


### PR DESCRIPTION
watch.js was not building the Proms JS/CSS static files when loading the site for the first time in development environment (it was rebuilding them as soon as one file was changed in frontend/src folder - so we did not detect the problem earlier)