### PR TITLE
rdrf #1305 New step and modified feature for checking PROMS options

### DIFF
--- a/rdrf/rdrf/testing/behaviour/features/ciccrc_general.feature
+++ b/rdrf/rdrf/testing/behaviour/features/ciccrc_general.feature
@@ -23,4 +23,7 @@ Feature: General functionality of CIC Clinical (ICHOMCRC).
     And the sidebar contains a link in section "Modules" to "BCCA - Bi-national Colorectal Cancer Audit"
     Then I click "Proms" in sidebar
     And the sidebar contains a link to "Demographics"
-    And I check the available survey options
+    And I should see survey name option "Baseline PROMS"
+    And I should see survey name option "FollowUp PROMS"
+    And I should see communication type option "QRCode"
+    And I should see communication type option "Email"

--- a/rdrf/rdrf/testing/behaviour/features/ciccrc_navigate.feature
+++ b/rdrf/rdrf/testing/behaviour/features/ciccrc_navigate.feature
@@ -15,7 +15,10 @@ Feature: Navigate CIC Clinical (ICHOMCRC).
     And location is "Consents"
     Then I click "Proms" in sidebar
     And location is "Patient Reported Outcomes"
-    And I check the available survey options
+    And I should see survey name option "Baseline PROMS"
+    And I should see survey name option "FollowUp PROMS"
+    And I should see communication type option "QRCode"
+    And I should see communication type option "Email"
     Then I click "Patient Information" in sidebar  
     And location is "Modules/Patient Information"
     Then I click "Baseline PROMS" in sidebar
@@ -40,7 +43,10 @@ Feature: Navigate CIC Clinical (ICHOMCRC).
     And location is "Consents"
     Then I click "Proms" in sidebar
     And location is "Patient Reported Outcomes"
-    And I check the available survey options
+    And I should see survey name option "Baseline PROMS"
+    And I should see survey name option "FollowUp PROMS"
+    And I should see communication type option "QRCode"
+    And I should see communication type option "Email"
     Then I click "Patient Information" in sidebar  
     And location is "Modules/Patient Information"
     Then I click "Baseline PROMS" in sidebar

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -934,5 +934,5 @@ def proms_checks(step, which, option):
     if not find_option(label=which.capitalize(), option=option):
         raise Exception(
             "Unable to find %s option %s"
-            % (which, name)
+            % (which, option)
         )

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -910,21 +910,28 @@ def sidebar_contains_link_in_section(step, sec, name):
         )
 
 
-@step('should see (survey name|communication type) option "(.*)"')
-def proms_checks(step, which, name):
-    assert world.browser.current_url.endswith("/clinicalproms"),\
-        "Not on PROMS request page!"
+def find_option(label, option):
+    """
+    Helper function for finding an option in a list.
+    Returns None if the object isn't found.
+    """
     xp = (
-        "//label[@for='id_%s']/following-sibling::select"
-        "/option[text()='%s']"
-        % (
-            "_".join(which.split()),
-            name
-        )
+        "//label[contains(.,\"%s\")]/following-sibling::*"
+        "//option[contains(.,\"%s\")]"
+        % (label, option)
     )
     try:
-        find(xp)
+        item = find(xp)
     except Nse:
+        item = None
+    return item
+
+
+@step('should see (survey name|communication type) option "(.*)"')
+def proms_checks(step, which, option):
+    assert world.browser.current_url.endswith("/clinicalproms"),\
+        "Not on PROMS request page!"
+    if not find_option(label=which.capitalize(), option=option):
         raise Exception(
             "Unable to find %s option %s"
             % (which, name)

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -871,42 +871,6 @@ def return_to_patientlisting(step):
     )
 
 
-@step('I check the available survey options')
-def check_proms_lists(step):
-    """
-    Check that the lists of options for surveys
-    and communication methods are correct.
-    """
-    # First check if on the PROMS page;
-    assert world.browser.current_url.endswith("/clinicalproms"),\
-        "Not on PROMS request page!"
-    # Create empty objects;
-    request_type_list = []
-    comms_type_list = []
-    # Press the add button and check if fades in;
-    find("//a[contains(@class, 'btn btn-info')]").click()
-    time.sleep(0.5)
-    fade1 = find("//div[contains(@class, 'modal fade')]").get_attribute("style")
-    assert not fade1.startswith("display: none"),\
-        "Seems fade-in has not appeared"
-    # Populate lists;
-    for element in find_multiple("//select[@name='survey_name']/option"):
-        request_type_list.append(element.get_attribute("value"))
-    for element in find_multiple("//select[@name='communication_type']/option"):
-        comms_type_list.append(element.get_attribute("value"))
-    # Cancel out and check for fadeout;
-    find("//button[@id='close_button']").click()
-    time.sleep(0.5)
-    fade2 = find("//div[contains(@class, 'modal fade')]").get_attribute("style")
-    assert not fade2.startswith("display: block"),\
-        "Seems fade-in has not disappeared"
-    # Assertions to finish;
-    assert request_type_list == ["BaselinePROMS", "FollowUpPROMS"],\
-        "Available PROMS types not BaselinePROMS and FollowUpPROMS"
-    assert comms_type_list == ["qrcode", "email"],\
-        "Available communications types not qrcode and email"
-
-
 @step('sidebar contains a section named "(.*)"')
 def sidebar_contains_section(step, name):
     try:
@@ -943,4 +907,25 @@ def sidebar_contains_link_in_section(step, sec, name):
         raise Exception(
             "Could not find a link to %s in section %s in sidebar"
             % (name, sec)
+        )
+
+
+@step('should see (survey name|communication type) option "(.*)"')
+def proms_checks(step, which, name):
+    assert world.browser.current_url.endswith("/clinicalproms"),\
+        "Not on PROMS request page!"
+    xp = (
+        "//label[@for='id_%s']/following-sibling::select"
+        "/option[text()='%s']"
+        % (
+            "_".join(which.split()),
+            name
+        )
+    )
+    try:
+        find(xp)
+    except Nse:
+        raise Exception(
+            "Unable to find %s option %s"
+            % (which, name)
         )


### PR DESCRIPTION
Removed previous step for checking PROMS options and replaced with new step.

  - The previous step was not very transparent; It was not clear what the expectation of the step was by reading the feature file, hence the new step is more explicit.
  - Two separate steps were able to be combined into one; The first capture group defines which menu is examined. The menu title is used to define which.
  - The feature `ciccrc_general.feature` was modified, as opposed to creating a new feature; This is partly because this feature already tests the PROMS options, but it was also necessary to modify the feature to remove a reference to the previous step.
