### PR TITLE
rdrf #1299 2fa page cancel url modified

### DIFF
--- a/rdrf/rdrf/context_processors/context_processors.py
+++ b/rdrf/rdrf/context_processors/context_processors.py
@@ -20,3 +20,9 @@ def cic_system_role(request):
                                                     SystemRoles.CIC_PROMS
                                                     ),
     }
+
+
+def is_proms_system(request):
+    return {
+        'is_proms_system': settings.SYSTEM_ROLE == SystemRoles.CIC_PROMS
+    }

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -132,6 +132,7 @@ TEMPLATES = [
                 "rdrf.context_processors.context_processors.production",
                 "rdrf.context_processors.context_processors.common_settings",
                 "rdrf.context_processors.context_processors.cic_system_role",
+                "rdrf.context_processors.context_processors.is_proms_system",
 
             ],
             "debug": DEBUG,

--- a/rdrf/rdrf/templates/two_factor/_wizard_actions.html
+++ b/rdrf/rdrf/templates/two_factor/_wizard_actions.html
@@ -8,7 +8,11 @@
         {% elif request.user.is_patient %}
             <a href="{% url 'patient_page' request.user.registry_code %}" class="btn btn-link pull-right">{% trans "Cancel" %}</a>
         {% else %}
-            <a href="{% url 'patientslisting' %}" class="btn btn-link pull-right">{% trans "Cancel" %}</a>
+            {% if is_proms_system %}
+                <a href="{% url 'logout' %}" class="btn btn-link pull-right">{% trans "Cancel" %}</a>
+            {% else %}
+                <a href="{% url 'patientslisting' %}" class="btn btn-link pull-right">{% trans "Cancel" %}</a>
+            {% endif %}
         {% endif %}
     {% elif cancel_url %}
         <a href="{{ cancel_url }}" class="btn btn-link pull-right">{% trans "Cancel" %}</a>


### PR DESCRIPTION
Cancel link on 2fa page of PROMS system was poining to the url 'patientlisting' which is not exposed in PROMS. As a fix, the Cancel link was made to point to 'logout' url iconditionally (only if it is a PROMS system else will point to 'patientlisting' url)

This condition assumes that PROMS system has the env varibale SYSTEM_ROLE set to SystemRoles.CIC_PROMS