### PR TITLE
rdrf #1327 workflow for curators added for resetting password

### DIFF
--- a/rdrf/rdrf/auth/__init__.py
+++ b/rdrf/rdrf/auth/__init__.py
@@ -8,4 +8,4 @@ def is_user_privileged(user):
 def can_user_self_unlock(user):
     return (
         getattr(settings, 'ACCOUNT_SELF_UNLOCK_ENABLED', False) and not
-        is_user_privileged(user) and not user.is_curator and not user.prevent_self_unlock)
+        is_user_privileged(user) and not user.prevent_self_unlock)

--- a/rdrf/rdrf/auth/__init__.py
+++ b/rdrf/rdrf/auth/__init__.py
@@ -8,4 +8,4 @@ def is_user_privileged(user):
 def can_user_self_unlock(user):
     return (
         getattr(settings, 'ACCOUNT_SELF_UNLOCK_ENABLED', False) and not
-        is_user_privileged(user) and not user.prevent_self_unlock)
+        is_user_privileged(user) and not user.is_curator and not user.prevent_self_unlock)

--- a/rdrf/rdrf/auth/forms.py
+++ b/rdrf/rdrf/auth/forms.py
@@ -86,6 +86,7 @@ class RDRFLoginAssistanceForm(PasswordResetForm):
             domain_override=None,
             subject_template_name='registration/login_assistance_subject.txt',
             email_template_name='registration/login_assistance_email.html',
+            password_reset_email_template_name='registration/password_reset_email.html',
             account_unlocked_email_template_name='registration/login_assistance_account_not_locked_email.html',
             can_not_self_unlock_email_template_name='registration/login_assistance_can_not_self_unlock_email.html',
             use_https=False,
@@ -105,6 +106,8 @@ class RDRFLoginAssistanceForm(PasswordResetForm):
         def _choose_template(user):
             if user.is_active:
                 return subject_template_name, account_unlocked_email_template_name
+            if user.is_curator:
+                return subject_template_name, password_reset_email_template_name
             if not can_user_self_unlock(user):
                 return subject_template_name, can_not_self_unlock_email_template_name
 


### PR DESCRIPTION
The MTM Curator users were not allowed to reset password when they get locked out (due to wrong password attempts). Instead, they used to get an email with instruction to contact admin.

This was fixed in this by allowing Curator users to set a new password when they get locked out.
They get an email with a secure password reset link when they submit their email from the password_assistance form.

[password_workflow_before.pdf](https://github.com/muccg/rdrf/files/4686580/password_workflow_before.pdf)

[password_workflow_after.pdf](https://github.com/muccg/rdrf/files/4686578/password_workflow_after.pdf)
