### PR TITLE
rdrf #1336 Integer CDEs' spec min and max set to default values

### DIFF
--- a/rdrf/rdrf/models/proms/models.py
+++ b/rdrf/rdrf/models/proms/models.py
@@ -159,10 +159,12 @@ class SurveyQuestion(models.Model):
                 "allow_multiple": self.cde.allow_multiple,  # allow for multiselect options
             }
         elif self.cde.datatype == 'integer':
+            min = int(self.cde.min_value) or 0
+            max = int(self.cde.max_value) or min + 100
             return {
                 "tag": "integer",
-                "max": int(self.cde.max_value),
-                "min": int(self.cde.min_value),
+                "max": max,
+                "min": min,
             }
 
     @property

--- a/rdrf/rdrf/models/proms/models.py
+++ b/rdrf/rdrf/models/proms/models.py
@@ -159,8 +159,8 @@ class SurveyQuestion(models.Model):
                 "allow_multiple": self.cde.allow_multiple,  # allow for multiselect options
             }
         elif self.cde.datatype == 'integer':
-            min = int(self.cde.min_value) or 0
-            max = int(self.cde.max_value) or min + 100
+            min = int(self.cde.min_value or 0)
+            max = int(self.cde.max_value or min + 100)
             return {
                 "tag": "integer",
                 "max": max,


### PR DESCRIPTION
 Integer CDEs' spec - min and max set to default values, 
if min_value and max_value are missing in CDE.