### PR TITLE
rdrf #1427 added contains operator for preconditions

### DIFF
--- a/rdrf/rdrf/frontend/src/pages/proms_page/logic.ts
+++ b/rdrf/rdrf/frontend/src/pages/proms_page/logic.ts
@@ -12,8 +12,15 @@ interface OrCondition {
     value: any,
 }
 
+interface ContainsCondition {
+    op: 'contains',
+    cde: string,
+    value: any,
+}
+
+
 // maybe this is enough
-type Condition = EqualsCondition | OrCondition;
+type Condition = EqualsCondition | OrCondition | ContainsCondition
 
 // Elements of workflow
 // I tried to make UnconditionalElement just a string but got type errors
@@ -121,6 +128,9 @@ function evalCondition(cond: Condition, state: any): boolean {
                 return answer === cond.value;
 	    case 'or':
 		return cond.value.indexOf(answer) > -1;
+	    case 'contains':
+		const result:boolean = answer.includes(cond.value);
+		return result;
             default:
                 return false; // extend this later
         }

--- a/rdrf/rdrf/models/proms/models.py
+++ b/rdrf/rdrf/models/proms/models.py
@@ -145,6 +145,8 @@ class SurveyQuestion(models.Model):
                 cond_block = {"op": "=",
                               "cde": self.precondition.cde.code,
                               "value": self.precondition.value}
+                if self.precondition.cde.allow_multiple:
+                    cond_block["op"] = "contains"
 
             return {"tag": "cond",
                     "cde": self.cde.code,


### PR DESCRIPTION
Multiselect cdes have been used as preconditions in Breast cancer:

If a multiselect has value [a,c] and the precondition value is c the expression evaluated is: does [a,c] include c ( true )

