### PR TITLE
rdrf #1475 Short script to export registry .zip, assuming local prepared

### DIFF
--- a/scripts/export_zip.sh
+++ b/scripts/export_zip.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/sh
+
+# -----------------------------------------------------------------------------
+# Intended to be used as; ./export_zip.sh REGISTRY_CODE
+# i.e. Argument 1 must be the registry code.
+# Further, the assumption is made that the YAML has been imported, the users
+# swapped over, and at least one model patient is present.
+# -----------------------------------------------------------------------------
+
+docker exec -it rdrf_runserver_1 /app/docker-entrypoint.sh \
+  django-admin export registry --registry-code $1
+


### PR DESCRIPTION
- Assumes that the local version of staging has been prepared.
- Exports .zip to `data/dev/`

Closes #1475.