### PR TITLE
rdrf #1114 SurveyRequest email template_data modified

### DIFF
--- a/rdrf/rdrf/models/proms/models.py
+++ b/rdrf/rdrf/models/proms/models.py
@@ -381,7 +381,7 @@ class SurveyRequest(models.Model):
                         "patient_email": self.patient.email,
                         "email_link": self.email_link,
                         "registry_name": self.registry.name,
-                        "survey_name": self.survey_name
+                        "survey_name": self.display_name
                     }
                     process_notification(self.registry.code,
                                          EventType.SURVEY_REQUEST,


### PR DESCRIPTION
- template_data includes survey_name variable that was set to name of survey
- changed this to display_name instead