### PR TITLE
rdrf #1607 Updated Django to 2.2.16

### DIFF
--- a/rdrf/setup.py
+++ b/rdrf/setup.py
@@ -6,7 +6,7 @@ start_dir = os.getcwd()
 requirements = [
     "ccg-django-utils==0.4.2",
     "celery==4.4.7",
-    "Django==2.2.13",
+    "Django==2.2.16",
     "django-anymail==7.2.1",
     "django-ajax-selects==1.9.1",
     "django-countries==6.1.3",


### PR DESCRIPTION
Django has been successfully upgraded to the latest patch release (2.2.16).