### PR TITLE
rdrf #1614 Updated pycountry dependency & added exception handling for LookupError

### DIFF
--- a/rdrf/rdrf/forms/widgets/widgets.py
+++ b/rdrf/rdrf/forms/widgets/widgets.py
@@ -235,6 +235,8 @@ class StateWidget(widgets.Select):
             state = pycountry.subdivisions.get(code=value)
         except KeyError:
             state = None
+        except LookupError:
+            state = None
 
         if state is not None:
             country_states = pycountry.subdivisions.get(country_code=state.country.alpha_2)

--- a/rdrf/setup.py
+++ b/rdrf/setup.py
@@ -27,7 +27,7 @@ requirements = [
     "openpyxl==3.0.5",
     "polib==1.1.0",
     "psycopg2==2.8.6",
-    "pycountry==19.8.18",
+    "pycountry==20.7.3",
     "pyinotify==0.9.6",
     "pyodbc==4.0.30",
     "pyparsing==2.4.7",


### PR DESCRIPTION
Updated pycountry from 19.8.18 to 20.7.3, and added exception handling to `rdrf/rdrf/forms/widgets/widgets.py` to account for a LookupError now thrown when the subdivision is left blank.