### PR TITLE
rdrf #1618 Added feature to test for missing country & step to check for alert boxes

### DIFF
--- a/rdrf/rdrf/testing/behaviour/features/fh_add_patient_empty_address_country.feature
+++ b/rdrf/rdrf/testing/behaviour/features/fh_add_patient_empty_address_country.feature
@@ -22,5 +22,4 @@ Feature: Add a patient and add an address with no country
     And I fill out "Suburb" in "Patient Address" section "1" with "Perth"
     And I fill out "Postcode" in "Patient Address" section "1" with "6000"
     And I press the "Save" button
-    Then I should see an error message
-    And I should see "Patient Address country: This field is required"
+    Then I should see an error message saying "Patient Address country: This field is required"

--- a/rdrf/rdrf/testing/behaviour/features/fh_add_patient_empty_address_country.feature
+++ b/rdrf/rdrf/testing/behaviour/features/fh_add_patient_empty_address_country.feature
@@ -1,0 +1,26 @@
+Feature: Add a patient and add an address with no country
+  As a user of FH
+  I want new patients to be added with a valid country value in address
+
+  Background:
+    Given export "fh.zip"
+    Given a registry named "FH Registry"
+
+  Scenario: Clinical staff attempts to add new patient with no country selected for address
+    When I am logged in as curator
+    And I click "Menu"
+    And I click "Patient List"
+    And I press the "Add Patient" button
+    And I select "FH Registry" from "Rdrf Registry"
+    And I select "fh Fiona Stanley Hospital" from "Centre"
+    And I fill in "Family Name" with "Baston"
+    And I fill in "Given Names" with "Billy"
+    And I fill in "Date of birth" with "10-09-2002"
+    And I select "Male" from "Sex"
+    And I click the add button in "Patient Address" section
+    And I fill out "Address" textarea in "Patient Address" section "1" with "39 Hercules Close"
+    And I fill out "Suburb" in "Patient Address" section "1" with "Perth"
+    And I fill out "Postcode" in "Patient Address" section "1" with "6000"
+    And I press the "Save" button
+    Then I should see an error message
+    And I should see "Patient Address country: This field is required"

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1386,4 +1386,4 @@ def check_alert_msg(step, message):
     }
 
     xp = '//*[contains(@class, "{0}")]'.format(msg_type[message])
-    find(xp) # find() asserts that the element can be found, so further checks not required
+    find(xp)  # find() asserts that the element can be found, so further checks not required

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1363,7 +1363,7 @@ def select_cust_act(step, action):
     find(xp).click()
 
 
-@step(r'should see (\d+) "([^\"]+)" element[s]?')
+@step(r'should see (\d+) "([^\"]+)" elements?')
 def check_elements(step, number, type):
     xp = ''
 
@@ -1375,3 +1375,15 @@ def check_elements(step, number, type):
     web_elements = find_multiple(xp)
     assert len(web_elements) == int(number),\
         'Unexpected number of elements: {0}'.format(len(web_elements))
+
+
+@step('should see an? (success|error|info) message')
+def check_alert_msg(step, message):
+    msg_type = {
+        "success": "alert alert-success",
+        "error": "alert alert-danger",
+        "info": "alert alert-alert alert-info",
+    }
+
+    xp = '//*[contains(@class, "{0}")]'.format(msg_type[message])
+    find(xp) # find() asserts that the element can be found, so further checks not required

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1387,3 +1387,16 @@ def check_alert_msg(step, message):
 
     xp = '//*[contains(@class, "{0}")]'.format(msg_type[message])
     find(xp)  # find() asserts that the element can be found, so further checks not required
+
+
+@step('should see an? (success|error|info) message saying "([^\"]+)"')
+def check_alert_msg(step, mtype, message):
+    msg_type = {
+        "success": "alert alert-success",
+        "error": "alert alert-danger",
+        "info": "alert alert-alert alert-info",
+    }
+
+    xp = '//*[contains(@class, "{0}")]'.format(msg_type[mtype])
+    alertbox = find(xp)  # find() asserts that the element can be found, so further checks not required
+    assert message in alertbox.innerText, "Unable to find {0} message".format(mtype)

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1378,7 +1378,7 @@ def check_elements(step, number, type):
 
 
 @step('should see an? (success|error|info) message')
-def check_alert_msg(step, message):
+def check_alert_type(step, message):
     msg_type = {
         "success": "alert alert-success",
         "error": "alert alert-danger",


### PR DESCRIPTION
Added new step to `steps.py` to check for alert message boxes, and new feature `fh_add_patient_empty_address_country.feature` to test said step by checking for the error alert message when attempting to save a patient address without entering the country.