### PR TITLE
Rdrf #1603 Validation rules description added to CDE admin page

### DIFF
--- a/rdrf/rdrf/models/definition/models.py
+++ b/rdrf/rdrf/models/definition/models.py
@@ -812,7 +812,7 @@ class CommonDataElement(models.Model):
             if self.min_value is not None:
                 validation_rules_description += "\nWith a minimum value of %d" % self.min_value
 
-        elif self.is_required == True:
+        elif self.is_required is True:
             validation_rules_description += "\nMust be filled"
 
         else:

--- a/rdrf/rdrf/models/definition/models.py
+++ b/rdrf/rdrf/models/definition/models.py
@@ -799,24 +799,24 @@ class CommonDataElement(models.Model):
         validation_rules_description = "The %s CDE:" % self.code
 
         if self.datatype == "string":
-            validation_rules_description += "\nIs a character set"
+            validation_rules_description += "<br>Is a character string"
             if self.max_length is not None:
-                validation_rules_description += "\nWith a limit of %d characters" % self.max_length
+                validation_rules_description += "<br>With a limit of %d characters" % self.max_length
             if self.pattern is not None and self.pattern != "":
-                validation_rules_description += "\nThat must match the pattern \"%s\"" % self.pattern
+                validation_rules_description += "<br>That must match the pattern \"%s\"" % self.pattern
 
         elif self.datatype == "integer" or self.datatype == "float":
-            validation_rules_description += "\nIs a number"
+            validation_rules_description += "<br>Is a number"
             if self.max_value is not None:
-                validation_rules_description += "\nWith a maximum value of %d" % self.max_value
+                validation_rules_description += "<br>With a maximum value of %d" % self.max_value
             if self.min_value is not None:
-                validation_rules_description += "\nWith a minimum value of %d" % self.min_value
+                validation_rules_description += "<br>With a minimum value of %d" % self.min_value
 
         elif self.is_required is True:
-            validation_rules_description += "\nMust be filled"
+            validation_rules_description += "<br>Must be filled"
 
         else:
-            validation_rules_description += "\nHas no validation requirements"
+            validation_rules_description += "<br>Has no validation requirements"
 
         return validation_rules_description
 

--- a/rdrf/rdrf/models/definition/models.py
+++ b/rdrf/rdrf/models/definition/models.py
@@ -660,6 +660,10 @@ class CommonDataElement(models.Model):
     important = models.BooleanField(
         default=False, help_text="Indicate whether the field should be emphasised with a green asterisk")
 
+    validation_rules_description = models.CharField(
+        blank=True,
+        help_text="A description of the required rules for validating the field")
+
     def __str__(self):
         return "CDE %s:%s" % (self.code, self.name)
 

--- a/rdrf/rdrf/models/definition/models.py
+++ b/rdrf/rdrf/models/definition/models.py
@@ -660,10 +660,6 @@ class CommonDataElement(models.Model):
     important = models.BooleanField(
         default=False, help_text="Indicate whether the field should be emphasised with a green asterisk")
 
-    validation_rules_description = models.CharField(
-        blank=True,
-        help_text="A description of the required rules for validating the field")
-
     def __str__(self):
         return "CDE %s:%s" % (self.code, self.name)
 
@@ -798,6 +794,31 @@ class CommonDataElement(models.Model):
 
     def get_admin_link(self):
         return '<a href="{0}" target="_blank">{1}</a>'.format(self.get_admin_url(), self)
+
+    def get_val_description(self):
+        validation_rules_description = "The %s CDE:" % self.code
+
+        if self.datatype == "string":
+            validation_rules_description += "\nIs a character set"
+            if self.max_length is not None:
+                validation_rules_description += "\nWith a limit of %d characters" % self.max_length
+            if self.pattern is not None and self.pattern != "":
+                validation_rules_description += "\nThat must match the pattern \"%s\"" % self.pattern
+
+        elif self.datatype == "integer" or self.datatype == "float":
+            validation_rules_description += "\nIs a number"
+            if self.max_value is not None:
+                validation_rules_description += "\nWith a maximum value of %d" % self.max_value
+            if self.min_value is not None:
+                validation_rules_description += "\nWith a minimum value of %d" % self.min_value
+
+        elif self.is_required == True:
+            validation_rules_description += "\nMust be filled"
+
+        else:
+            validation_rules_description += "\nHas no validation requirements"
+
+        return validation_rules_description
 
 
 def validate_abnormality_condition(abnormality_condition, datatype):

--- a/rdrf/rdrf/templates/admin/change_form.html
+++ b/rdrf/rdrf/templates/admin/change_form.html
@@ -39,6 +39,9 @@
 <p class="thumbnail">
     {% block usage %}{% endblock %}
 </p>
+<p class="thumbnail">
+    {% block valdesc %}{% endblock %}
+</p>
 
 <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
 <div>

--- a/rdrf/rdrf/templates/admin/rdrf/commondataelement/change_form.html
+++ b/rdrf/rdrf/templates/admin/rdrf/commondataelement/change_form.html
@@ -3,3 +3,7 @@
 {% block usage %}
     This CDE is used in: {{ original.get_usage|safe }}
 {% endblock %}
+
+{% block valdesc %}
+    {{ original.get_val_description|safe }}
+{% endblock %}


### PR DESCRIPTION
Added `get_val_description` method to the `CommonDataElement` class in models.py, which is used in rdrf/rdrf/templates/admin/rdrf/commondataelement/change_form.html to display the validation rules currently set for the CDE on the CDE admin page.