### PR TITLE
Rdrf #1625 Added password reset workflow test

### DIFF
--- a/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
+++ b/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
@@ -8,7 +8,8 @@ Feature: Follow the password reset worflow in CIC CRC.
 
   Scenario: User selects the password reset link, enters their email and submits it, then checks that there have been no errors
     When I try to log in
-    And I click "Trouble signing in"
+    Then I should be on the login page
+    When I click "Trouble signing in"
     Then I should be on the password reset page
     When I enter the email "test@test.com"
     And I click the "Send" button

--- a/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
+++ b/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
@@ -1,4 +1,4 @@
-Feature: Follow the password reset worflow in CIC CRC.
+Feature: Follow the password reset workflow in CIC CRC.
   As a user of CIC CRC
   I should be able to use the password reset form without error.
 

--- a/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
+++ b/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
@@ -8,7 +8,7 @@ Feature: Follow the password reset worflow in CIC CRC.
 
   Scenario: User selects the password reset link, enters their email and submits it, then checks that there have been no errors
     When I try to log in
-    And I click "Trouble signing in?"
+    And I click "Trouble signing in"
     Then I should be on the password reset page
     When I enter the email "test@test.com"
     And I click the "Send" button

--- a/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
+++ b/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
@@ -7,8 +7,7 @@ Feature: Follow the password reset worflow in CIC CRC.
     Given a registry named "ICHOM Colorectal Cancer"
 
   Scenario: User selects the password reset link, enters their email and submits it, then checks that there have been no errors
-    When I try to log in
-    Then I should be on the login page
+    Given I try to log in
     When I click "Trouble signing in"
     Then I should be on the password reset page
     When I enter the email "test@test.com"

--- a/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
+++ b/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
@@ -1,4 +1,4 @@
-Feature: Blah blah blah password reset
+Feature: Follow the password reset worflow in CIC CRC.
   As a user of CIC CRC
   I should be able to use the password reset form without error.
 
@@ -7,7 +7,8 @@ Feature: Blah blah blah password reset
     Given a registry named "ICHOM Colorectal Cancer"
 
   Scenario: User selects the password reset link, enters their email and submits it, then checks that there have been no errors
-    When I click "Trouble signing in?"
+    When I try to log in
+    And I click "Trouble signing in?"
     Then I should be on the password reset page
     When I enter the email "test@test.com"
     And I click the "Send" button

--- a/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
+++ b/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
@@ -7,8 +7,9 @@ Feature: Follow the password reset worflow in CIC CRC.
     Given a registry named "ICHOM Colorectal Cancer"
 
   Scenario: User selects the password reset link, enters their email and submits it, then checks that there have been no errors
-    Given I try to log in
-    When I click "Trouble signing in"
+    When I go to the login page
+    Then I should be on the login page
+    When I click "Trouble signing in?"
     Then I should be on the password reset page
     When I enter the email "test@test.com"
     And I click the "Send" button

--- a/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
+++ b/rdrf/rdrf/testing/behaviour/features/ciccrc_passwordreset.feature
@@ -1,0 +1,15 @@
+Feature: Blah blah blah password reset
+  As a user of CIC CRC
+  I should be able to use the password reset form without error.
+
+  Background:
+    Given export "ciccrc.zip"
+    Given a registry named "ICHOM Colorectal Cancer"
+
+  Scenario: User selects the password reset link, enters their email and submits it, then checks that there have been no errors
+    When I click "Trouble signing in?"
+    Then I should be on the password reset page
+    When I enter the email "test@test.com"
+    And I click the "Send" button
+    Then I should be on the email sent page
+    And I should see the site with no errors

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1405,7 +1405,7 @@ def check_alert_msg(step, mtype, message):
 @step('go to the login page')
 def go_to_login_and_wait(step):
     try_to_login(step)
-    time.sleep(1000)
+    time.sleep(15)
 
 
 @step('should be on the password reset page')

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1402,9 +1402,20 @@ def check_alert_msg(step, mtype, message):
     assert message in alertbox.innerText, "Unable to find {0} message".format(mtype)
 
 
+reg_codes = {
+    "ICHOM Colorectal Cancer": "cicclinical",
+    "ICHOM Breast Cancer": "cicbc",
+    "ICHOM Lung Cancer": "ciclc",
+    "FH Registry": "fh",
+}
+
+
 @step('go to the login page')
 def go_to_login_and_wait(step):
-    world.browser.get("https://rdrf.ccgapps.com.au/cicclinical/account/login?next=/cicclinical/router/")
+    world.browser.get(
+        f"{world.site_url}{reg_codes[world.registry]}"
+        f"/account/login?next=/{reg_codes[world.registry]}/router/"
+    )
 
 
 @step('should be on the password reset page')

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -287,7 +287,7 @@ def click_submit_button(step, value):
     This enables us to click on button, input or a elements that look like buttons.
     """
     submit_element = world.browser.find_element_by_xpath(
-        "//*[@id='submit-btn' and @value='{0}']".format(value))
+        "//*[(@id='submit-btn' or @type='submit') and @value='{0}']".format(value))
     utils.click(submit_element)
 
 
@@ -1400,3 +1400,28 @@ def check_alert_msg(step, mtype, message):
     xp = '//*[contains(@class, "{0}")]'.format(msg_type[mtype])
     alertbox = find(xp)  # find() asserts that the element can be found, so further checks not required
     assert message in alertbox.innerText, "Unable to find {0} message".format(mtype)
+
+
+@step('should be on the password reset page')
+def check_reset_page(step):
+    xp = '//*[contains(text(), "Did you forget your username or password?")]'
+    find(xp)  # find() asserts that the element can be found, so further checks not required
+
+
+@step('enter the email "([^\"]+)"')
+def enter_reset_email(step, reset_email):
+    xp = '//input[@type="email"]'
+    text_box = s_find(xp)
+    text_box.clear()
+    text_box.send_keys(reset_email)
+
+
+@step('should be on the email sent page')
+def check_reset_page(step):
+    assert world.browser.current_url.endswith("/login_assistance_email_sent"), "Email not sent!"
+
+
+@step('should see the site with no errors')
+def check_no_runtime_error(step):
+    xp = '//nav[contains(@class, "navbar")]'
+    find(xp)  # find() asserts that the element can be found, so further checks not required

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1404,8 +1404,7 @@ def check_alert_msg(step, mtype, message):
 
 @step('go to the login page')
 def go_to_login_and_wait(step):
-    try_to_login(step)
-    time.sleep(15)
+    world.browser.get("https://rdrf.ccgapps.com.au/cicclinical/account/login?next=/cicclinical/router/")
 
 
 @step('should be on the password reset page')

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1402,6 +1402,12 @@ def check_alert_msg(step, mtype, message):
     assert message in alertbox.innerText, "Unable to find {0} message".format(mtype)
 
 
+@step('go to the login page')
+def go_to_login_and_wait(step):
+    try_to_login(step)
+    time.sleep(1000)
+
+
 @step('should be on the password reset page')
 def check_reset_page(step):
     xp = '//*[contains(text(), "Did you forget your username or password?")]'

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1422,7 +1422,7 @@ def enter_reset_email(step, reset_email):
 
 
 @step('should be on the email sent page')
-def check_reset_page(step):
+def check_email_sent_page(step):
     assert world.browser.current_url.endswith("/login_assistance_email_sent"), "Email not sent!"
 
 

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1413,8 +1413,7 @@ reg_codes = {
 @step('go to the login page')
 def go_to_login_and_wait(step):
     world.browser.get(
-        f"{world.site_url}{reg_codes[world.registry]}"
-        f"/account/login?next=/{reg_codes[world.registry]}/router/"
+        f"{world.site_url}account/login"
     )
 
 

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1439,6 +1439,7 @@ def check_email_sent_page(step):
 @step('should see the site with no errors')
 def check_no_runtime_error(step):
     xp = '//nav[contains(@class, "navbar")]'
+    find(xp)  # find() asserts that the element can be found, so further checks not required
 
 
 @step('go to the Common Data Element admin page')


### PR DESCRIPTION
Added new steps to `steps.py` and created `ciccrc_passwordreset.feature` to test that the workflow for sending an email to reset a user's password progresses as expected and causes no run-time errors.