### PR TITLE
Rdrf #1627 Added dynamic validation field display for CDE creation admin page

### DIFF
--- a/rdrf/rdrf/__init__.py
+++ b/rdrf/rdrf/__init__.py
@@ -1,7 +1,7 @@
 from .celery import app as celery_app
 # Ensures db router system check is registered
 
-VERSION = "6.3.0"
+VERSION = "6.3.1"
 __version__ = VERSION
 
 

--- a/rdrf/rdrf/templates/admin/rdrf/commondataelement/change_form.html
+++ b/rdrf/rdrf/templates/admin/rdrf/commondataelement/change_form.html
@@ -3,3 +3,96 @@
 {% block usage %}
     This CDE is used in: {{ original.get_usage|safe }}
 {% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script>
+        function setDTypeVal () {
+            function validatorsString () {
+                $("#id_pv_group").prop("selectedIndex", 0);
+                $("#id_allow_multiple").prop("checked", false);
+                $("#id_max_value").val("");
+                $("#id_min_value").val("");
+
+                $("div[class*='pv_group']").hide();
+                $("div[class*='allow_multiple']").hide();
+                $("div[class*='max_value']").hide();
+                $("div[class*='min_value']").hide();
+
+                $("div[class*='max_length']").show();
+                $("div[class*='pattern']").show();
+            }
+
+            function validatorsNum () {
+                $("#id_pv_group").prop("selectedIndex", 0);
+                $("#id_allow_multiple").prop("checked", false);
+                $("#id_max_length").val("");
+                $("#id_pattern").val("");
+
+                $("div[class*='pv_group']").hide();
+                $("div[class*='allow_multiple']").hide();
+                $("div[class*='max_length']").hide();
+                $("div[class*='pattern']").hide();
+
+                $("div[class*='max_value']").show();
+                $("div[class*='min_value']").show();
+            }
+
+            function validatorsRange () {
+                $("#id_max_length").val("");
+                $("#id_max_value").val("");
+                $("#id_min_value").val("");
+                $("#id_pattern").val("");
+
+                $("div[class*='max_length']").hide();
+                $("div[class*='max_value']").hide();
+                $("div[class*='min_value']").hide();
+                $("div[class*='pattern']").hide();
+
+                $("div[class*='pv_group']").show();
+                $("div[class*='allow_multiple']").show();
+            }
+
+            function validatorsOther () {
+                $("#id_pv_group").prop("selectedIndex", 0);
+                $("#id_allow_multiple").prop("checked", false);
+                $("#id_max_length").val("");
+                $("#id_max_value").val("");
+                $("#id_min_value").val("");
+                $("#id_pattern").val("");
+
+                $("div[class*='pv_group']").hide();
+                $("div[class*='allow_multiple']").hide();
+                $("div[class*='max_length']").hide();
+                $("div[class*='max_value']").hide();
+                $("div[class*='min_value']").hide();
+                $("div[class*='pattern']").hide();
+            }
+                
+            $("#id_datatype").change(function () {
+                //Find the datatype field, get the currently-selected value. and
+                //hide/show different fields based on the data type
+                switch($(this).val()) {
+                    case "string":
+                    case "alphanumeric":
+                        validatorsString();
+                        break;
+                    case "integer":
+                    case "float":
+                        validatorsNum();
+                        break;
+                    case "range":
+                        validatorsRange();
+                        break;
+                    case "date":
+                    case "boolean":
+                    case "calculated":
+                    case "file":
+                        validatorsOther();
+                        break;
+                }
+            })
+            .change();
+        }
+    </script>
+{% endblock %}

--- a/rdrf/rdrf/templates/admin/rdrf/commondataelement/change_form.html
+++ b/rdrf/rdrf/templates/admin/rdrf/commondataelement/change_form.html
@@ -4,6 +4,10 @@
     This CDE is used in: {{ original.get_usage|safe }}
 {% endblock %}
 
+{% block valdesc %}
+    {{ original.get_val_description|safe }}
+{% endblock %}
+
 {% block extrahead %}
     {{ block.super }}
     <script>

--- a/rdrf/rdrf/templates/rdrf_cdes/base.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/base.html
@@ -67,6 +67,8 @@
         $(document).ready(function () {
             addExtraValidationMethods();
 
+            setDTypeVal();
+
             $("#submit-btn").click(function () {
                 $("#main-form").submit();
             });

--- a/rdrf/rdrf/testing/behaviour/features/base_cde_page_validators.feature
+++ b/rdrf/rdrf/testing/behaviour/features/base_cde_page_validators.feature
@@ -18,9 +18,13 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should see the "Max value" field
     And I should see the "Min value" field
     And I should see the "Pattern" field
+    Then I reset the page
 
   Scenario: Admin user creates new CDE and selects String for the CDE data type
-    Given I should be on the CDE editing page
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
     When I select "String" from "Datatype"
     Then I should see the "Max length" field
     And I should see the "Pattern" field
@@ -28,9 +32,13 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
+    Then I reset the page
 
   Scenario: Admin user creates new CDE and selects Integer for the CDE data type
-    Given I should be on the CDE editing page
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
     When I select "Integer" from "Datatype"
     Then I should see the "Max value" field
     And I should see the "Min value" field
@@ -38,9 +46,13 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Pattern" field
+    Then I reset the page
 
   Scenario: Admin user creates new CDE and selects Decimal for the CDE data type
-    Given I should be on the CDE editing page
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
     When I select "Decimal" from "Datatype"
     Then I should see the "Max value" field
     And I should see the "Min value" field
@@ -48,9 +60,13 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Pattern" field
+    Then I reset the page
 
   Scenario: Admin user creates new CDE and selects Alpha Numeric for the CDE data type
-    Given I should be on the CDE editing page
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
     When I select "Alpha Numeric" from "Datatype"
     Then I should see the "Max length" field
     And I should see the "Pattern" field
@@ -58,9 +74,13 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
+    Then I reset the page
 
   Scenario: Admin user creates new CDE and selects Date for the CDE data type
-    Given I should be on the CDE editing page
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
     When I select "Date" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
@@ -68,9 +88,13 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
     And I should NOT see the "Pattern" field
+    Then I reset the page
 
   Scenario: Admin user creates new CDE and selects Boolean for the CDE data type
-    Given I should be on the CDE editing page
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
     When I select "Boolean" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
@@ -78,9 +102,13 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
     And I should NOT see the "Pattern" field
+    Then I reset the page
 
   Scenario: Admin user creates new CDE and selects Range for the CDE data type
-    Given I should be on the CDE editing page
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
     When I select "Range" from "Datatype"
     Then I should see the "Pv group" field
     And I should see the "Allow multiple" checkbox
@@ -88,9 +116,13 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
     And I should NOT see the "Pattern" field
+    Then I reset the page
 
   Scenario: Admin user creates new CDE and selects Calculated for the CDE data type
-    Given I should be on the CDE editing page
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
     When I select "Calculated" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
@@ -98,9 +130,13 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
     And I should NOT see the "Pattern" field
+    Then I reset the page
 
   Scenario: Admin user creates new CDE and selects File for the CDE data type
-    Given I should be on the CDE editing page
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
     When I select "File" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
@@ -108,6 +144,7 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
     And I should NOT see the "Pattern" field
+    Then I reset the page
 
 #These will be expanded on after initial testing
   #Scenario: Admin user changes the data type of a String CDE with max length and pattern set to Integer, then back

--- a/rdrf/rdrf/testing/behaviour/features/base_cde_page_validators.feature
+++ b/rdrf/rdrf/testing/behaviour/features/base_cde_page_validators.feature
@@ -18,14 +18,18 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should see the "Max value" field
     And I should see the "Min value" field
     And I should see the "Pattern" field
+    Then I enter "CDE_test" for the "Code" field
+    And I enter "test" for the "Name" field
+    And I select "String" from "Datatype"
+    And I save the CDE
 
   Scenario: Admin user creates new CDE and selects String for the CDE data type
     Given I am logged in as admin
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I enter "CDE_test1" for the "code" field
-    And I enter "test1" for the "name" field
+    When I enter "CDE_test1" for the "Code" field
+    And I enter "test1" for the "Name" field
     And I select "String" from "Datatype"
     Then I should see the "Max length" field
     And I should see the "Pattern" field
@@ -40,8 +44,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I enter "CDE_test2" for the "code" field
-    And I enter "test2" for the "name" field
+    When I enter "CDE_test2" for the "Code" field
+    And I enter "test2" for the "Name" field
     And I select "Integer" from "Datatype"
     Then I should see the "Max value" field
     And I should see the "Min value" field
@@ -56,8 +60,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I enter "CDE_test3" for the "code" field
-    And I enter "test3" for the "name" field
+    When I enter "CDE_test3" for the "Code" field
+    And I enter "test3" for the "Name" field
     And I select "Decimal" from "Datatype"
     Then I should see the "Max value" field
     And I should see the "Min value" field
@@ -72,8 +76,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I enter "CDE_test4" for the "code" field
-    And I enter "test4" for the "name" field
+    When I enter "CDE_test4" for the "Code" field
+    And I enter "test4" for the "Name" field
     And I select "Alpha Numeric" from "Datatype"
     Then I should see the "Max length" field
     And I should see the "Pattern" field
@@ -88,8 +92,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I enter "CDE_test5" for the "code" field
-    And I enter "test5" for the "name" field
+    When I enter "CDE_test5" for the "Code" field
+    And I enter "test5" for the "Name" field
     And I select "Date" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
@@ -104,8 +108,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I enter "CDE_test6" for the "code" field
-    And I enter "test6" for the "name" field
+    When I enter "CDE_test6" for the "Code" field
+    And I enter "test6" for the "Name" field
     And I select "Boolean" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
@@ -120,8 +124,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I enter "CDE_test7" for the "code" field
-    And I enter "test7" for the "name" field
+    When I enter "CDE_test7" for the "Code" field
+    And I enter "test7" for the "Name" field
     And I select "Range" from "Datatype"
     Then I should see the "Pv group" field
     And I should see the "Allow multiple" checkbox
@@ -136,8 +140,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I enter "CDE_test8" for the "code" field
-    And I enter "test8" for the "name" field
+    When I enter "CDE_test8" for the "Code" field
+    And I enter "test8" for the "Name" field
     And I select "Calculated" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
@@ -152,8 +156,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I enter "CDE_test9" for the "code" field
-    And I enter "test9" for the "name" field
+    When I enter "CDE_test9" for the "Code" field
+    And I enter "test9" for the "Name" field
     And I select "File" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox

--- a/rdrf/rdrf/testing/behaviour/features/base_cde_page_validators.feature
+++ b/rdrf/rdrf/testing/behaviour/features/base_cde_page_validators.feature
@@ -7,7 +7,7 @@ Feature: Hiding unneeded validation options on the CDE admin page
     Given export "ciccrc.zip"
     Given a registry named "ICHOM Colorectal Cancer"
 
-  Scenario: Admin user creates new CDE, but does not yet select a data type
+  Scenario: Admin user navigates to the CDE admin page and creates new CDE, but does not yet select a data type
     Given I am logged in as admin
     When I go to the Common Data Element admin page
     And I click the Add button
@@ -20,11 +20,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should see the "Pattern" field
 
   Scenario: Admin user creates new CDE and selects String for the CDE data type
-    Given I am logged in as admin
-    When I go to the Common Data Element admin page
-    And I click the Add button
-    Then I should be on the CDE editing page
-    When I select "string" from "datatype"
+    Given I should be on the CDE editing page
+    When I select "String" from "Datatype"
     Then I should see the "Max length" field
     And I should see the "Pattern" field
     And I should NOT see the "Pv group" field
@@ -33,11 +30,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Min value" field
 
   Scenario: Admin user creates new CDE and selects Integer for the CDE data type
-    Given I am logged in as admin
-    When I go to the Common Data Element admin page
-    And I click the Add button
-    Then I should be on the CDE editing page
-    When I select "integer" from "datatype"
+    Given I should be on the CDE editing page
+    When I select "Integer" from "Datatype"
     Then I should see the "Max value" field
     And I should see the "Min value" field
     And I should NOT see the "Max length" field
@@ -46,11 +40,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Pattern" field
 
   Scenario: Admin user creates new CDE and selects Decimal for the CDE data type
-    Given I am logged in as admin
-    When I go to the Common Data Element admin page
-    And I click the Add button
-    Then I should be on the CDE editing page
-    When I select "float" from "datatype"
+    Given I should be on the CDE editing page
+    When I select "Decimal" from "Datatype"
     Then I should see the "Max value" field
     And I should see the "Min value" field
     And I should NOT see the "Max length" field
@@ -59,11 +50,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Pattern" field
 
   Scenario: Admin user creates new CDE and selects Alpha Numeric for the CDE data type
-    Given I am logged in as admin
-    When I go to the Common Data Element admin page
-    And I click the Add button
-    Then I should be on the CDE editing page
-    When I select "alphanumeric" from "datatype"
+    Given I should be on the CDE editing page
+    When I select "Alpha Numeric" from "Datatype"
     Then I should see the "Max length" field
     And I should see the "Pattern" field
     And I should NOT see the "Pv group" field
@@ -72,11 +60,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Min value" field
 
   Scenario: Admin user creates new CDE and selects Date for the CDE data type
-    Given I am logged in as admin
-    When I go to the Common Data Element admin page
-    And I click the Add button
-    Then I should be on the CDE editing page
-    When I select "date" from "datatype"
+    Given I should be on the CDE editing page
+    When I select "Date" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Max length" field
@@ -85,11 +70,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Pattern" field
 
   Scenario: Admin user creates new CDE and selects Boolean for the CDE data type
-    Given I am logged in as admin
-    When I go to the Common Data Element admin page
-    And I click the Add button
-    Then I should be on the CDE editing page
-    When I select "boolean" from "datatype"
+    Given I should be on the CDE editing page
+    When I select "Boolean" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Max length" field
@@ -98,11 +80,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Pattern" field
 
   Scenario: Admin user creates new CDE and selects Range for the CDE data type
-    Given I am logged in as admin
-    When I go to the Common Data Element admin page
-    And I click the Add button
-    Then I should be on the CDE editing page
-    When I select "range" from "datatype"
+    Given I should be on the CDE editing page
+    When I select "Range" from "Datatype"
     Then I should see the "Pv group" field
     And I should see the "Allow multiple" checkbox
     And I should NOT see the "Max length" field
@@ -111,11 +90,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Pattern" field
 
   Scenario: Admin user creates new CDE and selects Calculated for the CDE data type
-    Given I am logged in as admin
-    When I go to the Common Data Element admin page
-    And I click the Add button
-    Then I should be on the CDE editing page
-    When I select "calculated" from "datatype"
+    Given I should be on the CDE editing page
+    When I select "Calculated" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Max length" field
@@ -124,11 +100,8 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should NOT see the "Pattern" field
 
   Scenario: Admin user creates new CDE and selects File for the CDE data type
-    Given I am logged in as admin
-    When I go to the Common Data Element admin page
-    And I click the Add button
-    Then I should be on the CDE editing page
-    When I select "file" from "datatype"
+    Given I should be on the CDE editing page
+    When I select "File" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Max length" field

--- a/rdrf/rdrf/testing/behaviour/features/base_cde_page_validators.feature
+++ b/rdrf/rdrf/testing/behaviour/features/base_cde_page_validators.feature
@@ -1,0 +1,142 @@
+Feature: Hiding unneeded validation options on the CDE admin page
+  As an owner of a registry on RDRF
+  I want administrators to only use the correct CDE validation options
+  Depending on the data type of the CDE created
+
+  Background:
+    Given export "ciccrc.zip"
+    Given a registry named "ICHOM Colorectal Cancer"
+
+  Scenario: Admin user creates new CDE, but does not yet select a data type
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
+    And I should see the "Pv group" field
+    And I should see the "Allow multiple" checkbox
+    And I should see the "Max length" field
+    And I should see the "Max value" field
+    And I should see the "Min value" field
+    And I should see the "Pattern" field
+
+  Scenario: Admin user creates new CDE and selects String for the CDE data type
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
+    When I select "string" from "datatype"
+    Then I should see the "Max length" field
+    And I should see the "Pattern" field
+    And I should NOT see the "Pv group" field
+    And I should NOT see the "Allow multiple" checkbox
+    And I should NOT see the "Max value" field
+    And I should NOT see the "Min value" field
+
+  Scenario: Admin user creates new CDE and selects Integer for the CDE data type
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
+    When I select "integer" from "datatype"
+    Then I should see the "Max value" field
+    And I should see the "Min value" field
+    And I should NOT see the "Max length" field
+    And I should NOT see the "Pv group" field
+    And I should NOT see the "Allow multiple" checkbox
+    And I should NOT see the "Pattern" field
+
+  Scenario: Admin user creates new CDE and selects Decimal for the CDE data type
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
+    When I select "float" from "datatype"
+    Then I should see the "Max value" field
+    And I should see the "Min value" field
+    And I should NOT see the "Max length" field
+    And I should NOT see the "Pv group" field
+    And I should NOT see the "Allow multiple" checkbox
+    And I should NOT see the "Pattern" field
+
+  Scenario: Admin user creates new CDE and selects Alpha Numeric for the CDE data type
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
+    When I select "alphanumeric" from "datatype"
+    Then I should see the "Max length" field
+    And I should see the "Pattern" field
+    And I should NOT see the "Pv group" field
+    And I should NOT see the "Allow multiple" checkbox
+    And I should NOT see the "Max value" field
+    And I should NOT see the "Min value" field
+
+  Scenario: Admin user creates new CDE and selects Date for the CDE data type
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
+    When I select "date" from "datatype"
+    Then I should NOT see the "Pv group" field
+    And I should NOT see the "Allow multiple" checkbox
+    And I should NOT see the "Max length" field
+    And I should NOT see the "Max value" field
+    And I should NOT see the "Min value" field
+    And I should NOT see the "Pattern" field
+
+  Scenario: Admin user creates new CDE and selects Boolean for the CDE data type
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
+    When I select "boolean" from "datatype"
+    Then I should NOT see the "Pv group" field
+    And I should NOT see the "Allow multiple" checkbox
+    And I should NOT see the "Max length" field
+    And I should NOT see the "Max value" field
+    And I should NOT see the "Min value" field
+    And I should NOT see the "Pattern" field
+
+  Scenario: Admin user creates new CDE and selects Range for the CDE data type
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
+    When I select "range" from "datatype"
+    Then I should see the "Pv group" field
+    And I should see the "Allow multiple" checkbox
+    And I should NOT see the "Max length" field
+    And I should NOT see the "Max value" field
+    And I should NOT see the "Min value" field
+    And I should NOT see the "Pattern" field
+
+  Scenario: Admin user creates new CDE and selects Calculated for the CDE data type
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
+    When I select "calculated" from "datatype"
+    Then I should NOT see the "Pv group" field
+    And I should NOT see the "Allow multiple" checkbox
+    And I should NOT see the "Max length" field
+    And I should NOT see the "Max value" field
+    And I should NOT see the "Min value" field
+    And I should NOT see the "Pattern" field
+
+  Scenario: Admin user creates new CDE and selects File for the CDE data type
+    Given I am logged in as admin
+    When I go to the Common Data Element admin page
+    And I click the Add button
+    Then I should be on the CDE editing page
+    When I select "file" from "datatype"
+    Then I should NOT see the "Pv group" field
+    And I should NOT see the "Allow multiple" checkbox
+    And I should NOT see the "Max length" field
+    And I should NOT see the "Max value" field
+    And I should NOT see the "Min value" field
+    And I should NOT see the "Pattern" field
+
+#These will be expanded on after initial testing
+  #Scenario: Admin user changes the data type of a String CDE with max length and pattern set to Integer, then back
+  #Scenario: Admin user changes the data type of an Integer CDE with max value and min value set to String, then back
+  #Scenario: Admin user changes the data type of a Range CDE with PV group set and allow multiple checked to another type, then back

--- a/rdrf/rdrf/testing/behaviour/features/base_cde_page_validators.feature
+++ b/rdrf/rdrf/testing/behaviour/features/base_cde_page_validators.feature
@@ -7,7 +7,7 @@ Feature: Hiding unneeded validation options on the CDE admin page
     Given export "ciccrc.zip"
     Given a registry named "ICHOM Colorectal Cancer"
 
-  Scenario: Admin user navigates to the CDE admin page and creates new CDE, but does not yet select a data type
+  Scenario: Admin user creates new CDE, but does not yet select a data type
     Given I am logged in as admin
     When I go to the Common Data Element admin page
     And I click the Add button
@@ -18,133 +18,150 @@ Feature: Hiding unneeded validation options on the CDE admin page
     And I should see the "Max value" field
     And I should see the "Min value" field
     And I should see the "Pattern" field
-    Then I reset the page
 
   Scenario: Admin user creates new CDE and selects String for the CDE data type
     Given I am logged in as admin
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I select "String" from "Datatype"
+    When I enter "CDE_test1" for the "code" field
+    And I enter "test1" for the "name" field
+    And I select "String" from "Datatype"
     Then I should see the "Max length" field
     And I should see the "Pattern" field
     And I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
-    Then I reset the page
+    Then I save the CDE
 
   Scenario: Admin user creates new CDE and selects Integer for the CDE data type
     Given I am logged in as admin
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I select "Integer" from "Datatype"
+    When I enter "CDE_test2" for the "code" field
+    And I enter "test2" for the "name" field
+    And I select "Integer" from "Datatype"
     Then I should see the "Max value" field
     And I should see the "Min value" field
     And I should NOT see the "Max length" field
     And I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Pattern" field
-    Then I reset the page
+    Then I save the CDE
 
   Scenario: Admin user creates new CDE and selects Decimal for the CDE data type
     Given I am logged in as admin
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I select "Decimal" from "Datatype"
+    When I enter "CDE_test3" for the "code" field
+    And I enter "test3" for the "name" field
+    And I select "Decimal" from "Datatype"
     Then I should see the "Max value" field
     And I should see the "Min value" field
     And I should NOT see the "Max length" field
     And I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Pattern" field
-    Then I reset the page
+    Then I save the CDE
 
   Scenario: Admin user creates new CDE and selects Alpha Numeric for the CDE data type
     Given I am logged in as admin
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I select "Alpha Numeric" from "Datatype"
+    When I enter "CDE_test4" for the "code" field
+    And I enter "test4" for the "name" field
+    And I select "Alpha Numeric" from "Datatype"
     Then I should see the "Max length" field
     And I should see the "Pattern" field
     And I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
-    Then I reset the page
+    Then I save the CDE
 
   Scenario: Admin user creates new CDE and selects Date for the CDE data type
     Given I am logged in as admin
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I select "Date" from "Datatype"
+    When I enter "CDE_test5" for the "code" field
+    And I enter "test5" for the "name" field
+    And I select "Date" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Max length" field
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
     And I should NOT see the "Pattern" field
-    Then I reset the page
+    Then I save the CDE
 
   Scenario: Admin user creates new CDE and selects Boolean for the CDE data type
     Given I am logged in as admin
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I select "Boolean" from "Datatype"
+    When I enter "CDE_test6" for the "code" field
+    And I enter "test6" for the "name" field
+    And I select "Boolean" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Max length" field
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
     And I should NOT see the "Pattern" field
-    Then I reset the page
+    Then I save the CDE
 
   Scenario: Admin user creates new CDE and selects Range for the CDE data type
     Given I am logged in as admin
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I select "Range" from "Datatype"
+    When I enter "CDE_test7" for the "code" field
+    And I enter "test7" for the "name" field
+    And I select "Range" from "Datatype"
     Then I should see the "Pv group" field
     And I should see the "Allow multiple" checkbox
     And I should NOT see the "Max length" field
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
     And I should NOT see the "Pattern" field
-    Then I reset the page
+    Then I save the CDE
 
   Scenario: Admin user creates new CDE and selects Calculated for the CDE data type
     Given I am logged in as admin
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I select "Calculated" from "Datatype"
+    When I enter "CDE_test8" for the "code" field
+    And I enter "test8" for the "name" field
+    And I select "Calculated" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Max length" field
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
     And I should NOT see the "Pattern" field
-    Then I reset the page
+    Then I save the CDE
 
   Scenario: Admin user creates new CDE and selects File for the CDE data type
     Given I am logged in as admin
     When I go to the Common Data Element admin page
     And I click the Add button
     Then I should be on the CDE editing page
-    When I select "File" from "Datatype"
+    When I enter "CDE_test9" for the "code" field
+    And I enter "test9" for the "name" field
+    And I select "File" from "Datatype"
     Then I should NOT see the "Pv group" field
     And I should NOT see the "Allow multiple" checkbox
     And I should NOT see the "Max length" field
     And I should NOT see the "Max value" field
     And I should NOT see the "Min value" field
     And I should NOT see the "Pattern" field
-    Then I reset the page
+    Then I save the CDE
 
 #These will be expanded on after initial testing
   #Scenario: Admin user changes the data type of a String CDE with max length and pattern set to Integer, then back

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1403,7 +1403,7 @@ def check_alert_msg(step, mtype, message):
 
 
 @step('go to the Common Data Element admin page')
-def goto_CDE_admin(step):
+def goto_cde_admin(step):
     world.browser.get(world.site_url + "admin/rdrf/commondataelement/")
 
 
@@ -1412,7 +1412,7 @@ def click_add_button(step):
     '''
     This function is specific to the Add button as the existing generic function
     does not handle buttons other than submit buttons at this stage, and I am
-    unsure if I am permitted to overhaul existing functions due to the 
+    unsure if I am permitted to overhaul existing functions due to the
     potential issues that may occur.
     '''
     xp = '//a[contains(@id, "add_button")]'
@@ -1421,7 +1421,7 @@ def click_add_button(step):
 
 
 @step('should be on the CDE editing page')
-def check_add_CDE_page(step):
+def check_add_cde_page(step):
     xp = '//*[contains(text(), "This CDE is used in:")]'  # This text only appears on the CDE editing page
     find(xp)  # find() asserts that the element can be found, so further checks not required
 
@@ -1447,7 +1447,7 @@ def check_page_fields_show(step, field_name):
     id_elem = find(find_id_xp)
     id_var = id_elem.get_attribute('for')[3:]
     xp = f'//*[contains(@id, "{id_var}") and ancestor::*[contains(@class, "{id_var}") and not(contains(@style, "display: none"))]]'
-    find(xp) # find() asserts that the element can be found, so further checks not required
+    find(xp)  # find() asserts that the element can be found, so further checks not required
 
 
 @step('should NOT see the "([^\"]+)" (?=field|checkbox)')
@@ -1456,4 +1456,4 @@ def check_page_fields_hide(step, field_name):
     id_elem = find(find_id_xp)
     id_var = id_elem.get_attribute('for')[3:]
     xp = f'//*[contains(@id, "{id_var}") and ancestor::*[contains(@class, "{id_var}") and contains(@style, "display: none")]]'
-    find(xp) # find() asserts that the element can be found, so further checks not required
+    find(xp)  # find() asserts that the element can be found, so further checks not required

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1400,3 +1400,47 @@ def check_alert_msg(step, mtype, message):
     xp = '//*[contains(@class, "{0}")]'.format(msg_type[mtype])
     alertbox = find(xp)  # find() asserts that the element can be found, so further checks not required
     assert message in alertbox.innerText, "Unable to find {0} message".format(mtype)
+
+
+reg_codes = {
+    "ICHOM Colorectal Cancer": "cicclinical",
+    "ICHOM Breast Cancer": "cicbc",
+    "ICHOM Lung Cancer": "ciclc",
+    "FH Registry": "fh",
+}
+
+
+@step('go to the Common Data Element admin page')
+def goto_CDE_admin(step):
+    world.browser.get(world.site_url + "admin/rdrf/commondataelement/")
+
+
+@step('click the Add button')
+def click_add_button(step):
+    '''
+    This function is specific to the Add button as the existing generic function
+    does not handle buttons other than submit buttons at this stage, and I am
+    unsure if I am permitted to overhaul existing functions due to the 
+    potential issues that may occur.
+    '''
+    xp = '//*[contains(., "add_button")]'
+    add_btn = find(xp)
+    add_btn.click()
+
+
+@step('should be on the CDE editing page')
+def check_add_CDE_page(step):
+    xp = '//*[contains(text(), "This CDE is used in:")]'  # This text only appears on the CDE editing page
+    find(xp)  # find() asserts that the element can be found, so further checks not required
+
+
+@step('should see the "([^\"]+)" (field|checkbox)')
+def check_page_fields_show(step, field_name):
+    xp = f'//*[contains(@id, "{field_name}") and ancestor::*[contains(@class, "{field_name}") and not(contains(@style, "display: none"))]]'
+    find(xp) # find() asserts that the element can be found, so further checks not required
+
+
+@step('should NOT see the "([^\"]+)" (field|checkbox)')
+def check_page_fields_hide(step, field_name):
+    xp = f'//*[contains(@id, "{field_name}") and ancestor::*[contains(@class, "{field_name}") and contains(@style, "display: none")]]'
+    find(xp) # find() asserts that the element can be found, so further checks not required

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1437,8 +1437,8 @@ def fill_field(step, f_value, f_name):
 
 @step('save the CDE')
 def save_cde(step):
-    xp = '//input[contains(@name, "_save")]'
-    find(xp).click()
+    xp = '//form[contains(@id, "commondataelement_form")]'
+    find(xp).submit()
 
 
 @step('should see the "([^\"]+)" (?=field|checkbox)')

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1426,6 +1426,21 @@ def check_add_CDE_page(step):
     find(xp)  # find() asserts that the element can be found, so further checks not required
 
 
+@step('enter "([^\"]+)" for the "([^\"]+)" field')
+def fill_field(step, f_value, f_name):
+    find_id_xp = f'//*[contains(text(), "{f_name}")]'
+    id_elem = find(find_id_xp)
+    id_var = id_elem.get_attribute('for')
+    xp = f'//input[@type="text" and @id="{id_var}"]'
+    find(xp).send_keys(f"{f_value}")
+
+
+@step('save the CDE')
+def save_cde(step):
+    xp = '//input[contains(@name, "_save")]'
+    find(xp).click()
+
+
 @step('should see the "([^\"]+)" (?=field|checkbox)')
 def check_page_fields_show(step, field_name):
     find_id_xp = f'//*[contains(text(), "{field_name}")]'

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1423,7 +1423,7 @@ def click_add_button(step):
     unsure if I am permitted to overhaul existing functions due to the 
     potential issues that may occur.
     '''
-    xp = '//*[contains(., "add_button")]'
+    xp = '//a[contains(@id, "add_button")]'
     add_btn = find(xp)
     add_btn.click()
 
@@ -1434,13 +1434,19 @@ def check_add_CDE_page(step):
     find(xp)  # find() asserts that the element can be found, so further checks not required
 
 
-@step('should see the "([^\"]+)" (field|checkbox)')
+@step('should see the "([^\"]+)" (?=field|checkbox)')
 def check_page_fields_show(step, field_name):
-    xp = f'//*[contains(@id, "{field_name}") and ancestor::*[contains(@class, "{field_name}") and not(contains(@style, "display: none"))]]'
+    find_id_xp = f'//*[contains(text(), "{field_name}")]'
+    id_elem = find(find_id_xp)
+    id_var = id_elem.get_attribute('for')[3:]
+    xp = f'//*[contains(@id, "{id_var}") and ancestor::*[contains(@class, "{id_var}") and not(contains(@style, "display: none"))]]'
     find(xp) # find() asserts that the element can be found, so further checks not required
 
 
-@step('should NOT see the "([^\"]+)" (field|checkbox)')
+@step('should NOT see the "([^\"]+)" (?=field|checkbox)')
 def check_page_fields_hide(step, field_name):
-    xp = f'//*[contains(@id, "{field_name}") and ancestor::*[contains(@class, "{field_name}") and contains(@style, "display: none")]]'
+    find_id_xp = f'//*[contains(text(), "{field_name}")]'
+    id_elem = find(find_id_xp)
+    id_var = id_elem.get_attribute('for')[3:]
+    xp = f'//*[contains(@id, "{id_var}") and ancestor::*[contains(@class, "{id_var}") and contains(@style, "display: none")]]'
     find(xp) # find() asserts that the element can be found, so further checks not required

--- a/rdrf/rdrf/testing/behaviour/features/steps.py
+++ b/rdrf/rdrf/testing/behaviour/features/steps.py
@@ -1402,14 +1402,6 @@ def check_alert_msg(step, mtype, message):
     assert message in alertbox.innerText, "Unable to find {0} message".format(mtype)
 
 
-reg_codes = {
-    "ICHOM Colorectal Cancer": "cicclinical",
-    "ICHOM Breast Cancer": "cicbc",
-    "ICHOM Lung Cancer": "ciclc",
-    "FH Registry": "fh",
-}
-
-
 @step('go to the Common Data Element admin page')
 def goto_CDE_admin(step):
     world.browser.get(world.site_url + "admin/rdrf/commondataelement/")

--- a/rdrf/setup.py
+++ b/rdrf/setup.py
@@ -139,7 +139,7 @@ for package in ['rdrf', 'registry.common', 'registry.genetic',
 
 
 setup(name='django-rdrf',
-      version="6.3.0",
+      version="6.3.1",
       packages=find_packages(),
       description='RDRF',
       long_description='Rare Disease Registry Framework',


### PR DESCRIPTION
Added new script to `change_form.html` for the CDE creation admin page that hides and clears validators not used by the selected data type, as well as `base_cde_page_validators.feature` and the requisite steps in `steps.py` to perform automated tests of the script's functionality.