### PR TITLE
Rdrf #1690 API URL cleanup

### DIFF
--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -76,7 +76,6 @@ services:
       - WAIT_FOR_CACHE=1
       - DEIDENTIFIED_SITE_ID=testing
       - DJANGO_MAILGUN_API_KEY=${DJANGO_MAILGUN_API_KEY}
-      - SYSTEM_ROLE=CIC_CLINICAL
 
   celeryworker:
     image: muccg/rdrf-dev

--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -76,6 +76,7 @@ services:
       - WAIT_FOR_CACHE=1
       - DEIDENTIFIED_SITE_ID=testing
       - DJANGO_MAILGUN_API_KEY=${DJANGO_MAILGUN_API_KEY}
+      - SYSTEM_ROLE=CIC_CLINICAL
 
   celeryworker:
     image: muccg/rdrf-dev

--- a/rdrf/rdrf/services/rest/serializers.py
+++ b/rdrf/rdrf/services/rest/serializers.py
@@ -103,6 +103,7 @@ class CliniciansHyperlink(RegistryHyperlink):
 class PatientsHyperlink(RegistryHyperlink):
     view_name = 'patient-list'
 
+
 def get_clinicians_url():
     from django.conf import settings
 
@@ -110,6 +111,7 @@ def get_clinicians_url():
         return CliniciansHyperlink(read_only=True, source='*')
     else:
         return ""
+
 
 def get_meta_fields():
     from django.conf import settings
@@ -133,6 +135,7 @@ def get_meta_fields():
             'version',
             'url',
             'patients_url')
+
 
 class RegistrySerializer(serializers.HyperlinkedModelSerializer):
     # Add some more urls for better browsability

--- a/rdrf/rdrf/services/rest/serializers.py
+++ b/rdrf/rdrf/services/rest/serializers.py
@@ -1,9 +1,11 @@
+from django.conf import settings
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from registry.patients.models import Patient, Registry, Doctor, NextOfKinRelationship
 from registry.groups.models import CustomUser, WorkingGroup
 from rdrf.models.proms.models import SurveyAssignment
 from rdrf.models.definition.models import RegistryYaml
+from rdrf.system_role import SystemRoles
 
 
 class DoctorHyperlinkId(serializers.HyperlinkedRelatedField):
@@ -107,19 +109,30 @@ class PatientsHyperlink(RegistryHyperlink):
 class RegistrySerializer(serializers.HyperlinkedModelSerializer):
     # Add some more urls for better browsability
     patients_url = PatientsHyperlink(read_only=True, source='*')
-    clinicians_url = CliniciansHyperlink(read_only=True, source='*')
+    if settings.SYSTEM_ROLE == SystemRoles.NORMAL:
+        clinicians_url = CliniciansHyperlink(read_only=True, source='*')
 
     class Meta:
         model = Registry
-        fields = (
-            'pk',
-            'name',
-            'code',
-            'desc',
-            'version',
-            'url',
-            'patients_url',
-            'clinicians_url')
+        if settings.SYSTEM_ROLE == SystemRoles.NORMAL:
+            fields = (
+                'pk',
+                'name',
+                'code',
+                'desc',
+                'version',
+                'url',
+                'patients_url',
+                'clinicians_url')
+        else:
+            fields = (
+                'pk',
+                'name',
+                'code',
+                'desc',
+                'version',
+                'url',
+                'patients_url')
         extra_kwargs = {
             'url': {'lookup_field': 'code'},
         }

--- a/rdrf/rdrf/services/rest/urls/api_urls.py
+++ b/rdrf/rdrf/services/rest/urls/api_urls.py
@@ -1,6 +1,8 @@
 from django.urls import re_path
+from django.conf import settings
 from rdrf.services.rest.views import api_views
 from rdrf.routing.custom_rest_router import DefaultRouterWithSimpleViews
+from rdrf.system_role import SystemRoles
 
 
 router = DefaultRouterWithSimpleViews()
@@ -14,8 +16,11 @@ router.register(r'countries', api_views.ListCountries, basename='country')
 # router.register(r'laboratories', api_views.LookupLaboratories, basename='laboratory')
 router.register(r'registries/(?P<registry_code>\w+)/indices',
                 api_views.LookupIndex, basename='index')
-router.register(r'registries/(?P<registry_code>\w+)/clinicians',
-                api_views.ListClinicians, basename='clinician')
+
+if settings.SYSTEM_ROLE == SystemRoles.NORMAL:
+    router.register(r'registries/(?P<registry_code>\w+)/clinicians',
+                    api_views.ListClinicians, basename='clinician')
+
 router.register(r'calculatedcdes', api_views.CalculatedCdeValue, basename='calculatedcde')
 router.register(r'tasks/(?P<task_id>[0-9a-z_\-]+)', api_views.TaskInfoView, basename='task')
 router.register(r'taskdownloads/(?P<task_id>[0-9a-z_\-]+)',

--- a/rdrf/rdrf/services/rest/urls/api_urls.py
+++ b/rdrf/rdrf/services/rest/urls/api_urls.py
@@ -10,8 +10,8 @@ router.register(r'doctors', api_views.DoctorViewSet)
 router.register(r'nextofkinrelationship', api_views.NextOfKinRelationshipViewSet)
 router.register(r'workinggroups', api_views.WorkingGroupViewSet)
 router.register(r'countries', api_views.ListCountries, basename='country')
-router.register(r'genes', api_views.LookupGenes, basename='gene')
-router.register(r'laboratories', api_views.LookupLaboratories, basename='laboratory')
+#router.register(r'genes', api_views.LookupGenes, basename='gene')
+#router.register(r'laboratories', api_views.LookupLaboratories, basename='laboratory')
 router.register(r'registries/(?P<registry_code>\w+)/indices',
                 api_views.LookupIndex, basename='index')
 router.register(r'registries/(?P<registry_code>\w+)/clinicians',

--- a/rdrf/rdrf/services/rest/urls/api_urls.py
+++ b/rdrf/rdrf/services/rest/urls/api_urls.py
@@ -10,8 +10,8 @@ router.register(r'doctors', api_views.DoctorViewSet)
 router.register(r'nextofkinrelationship', api_views.NextOfKinRelationshipViewSet)
 router.register(r'workinggroups', api_views.WorkingGroupViewSet)
 router.register(r'countries', api_views.ListCountries, basename='country')
-#router.register(r'genes', api_views.LookupGenes, basename='gene')
-#router.register(r'laboratories', api_views.LookupLaboratories, basename='laboratory')
+# router.register(r'genes', api_views.LookupGenes, basename='gene')
+# router.register(r'laboratories', api_views.LookupLaboratories, basename='laboratory')
 router.register(r'registries/(?P<registry_code>\w+)/indices',
                 api_views.LookupIndex, basename='index')
 router.register(r'registries/(?P<registry_code>\w+)/clinicians',


### PR DESCRIPTION
Both the Genes and Laboratories API views have been de-registered. The Clinicians API view will now only be registered if the system is non-CIC.