### PR TITLE
RDRF #1779 Fixed setDTypeVal ReferenceError

### DIFF
--- a/rdrf/rdrf/templates/admin/rdrf/commondataelement/change_form.html
+++ b/rdrf/rdrf/templates/admin/rdrf/commondataelement/change_form.html
@@ -100,3 +100,8 @@
         }
     </script>
 {% endblock %}
+
+{% block morescripts %}
+    {{ block.super }}
+    setDTypeVal();
+{% endblock %}

--- a/rdrf/rdrf/templates/rdrf_cdes/base.html
+++ b/rdrf/rdrf/templates/rdrf_cdes/base.html
@@ -69,7 +69,7 @@
         $(document).ready(function () {
             addExtraValidationMethods();
 
-            setDTypeVal();
+            {% block morescripts %}{% endblock %}
 
             $("#submit-btn").click(function () {
                 $("#main-form").submit();


### PR DESCRIPTION
- setDTypeVal previously called in document ready function to
    correctly hide unneeded validators
- Used Django template functionality to create empty block
    (morescripts)
- Moved setDTypeVal call to new defined morescripts block in
    templates/admin/rdrf/commondataelement/change_form.html