### PR TITLE
rdrf #1859 Further hardened applicability condition evaluation

### DIFF
--- a/rdrf/rdrf/helpers/utils.py
+++ b/rdrf/rdrf/helpers/utils.py
@@ -903,7 +903,7 @@ def check_suspicious_sql(sql_query, user):
 
 def contains_blacklisted_words(text):
     return any(map(text.__contains__, ["socket", "process", "import", "system", "builtin",
-                                       "connect", "spawn", "delete"]))
+                                       "connect", "spawn", "delete", "eval"]))
 
 
 def is_filled(cde_model, value):

--- a/rdrf/rdrf/models/definition/models.py
+++ b/rdrf/rdrf/models/definition/models.py
@@ -1116,9 +1116,12 @@ class RegistryForm(models.Model):
         evaluation_context = {"patient": patient}
 
         try:
-            is_applicable = eval(self.applicability_condition,
-                                 {"__builtins__": None},
-                                 evaluation_context)
+            if applicability_condition_invalid(self.applicability_condition):
+                return False
+            else:
+                is_applicable = eval(self.applicability_condition,
+                                     {"__builtins__": None},
+                                     evaluation_context)
         except BaseException:
             # allows us to filter out forms for patients
             # which are not related with the assumed structure
@@ -1316,8 +1319,14 @@ class ConsentSection(models.Model):
 
             function_context = {"patient": patient, "self_patient": self_patient}
 
-            is_applicable = eval(
-                self.applicability_condition, {"__builtins__": None}, function_context)
+            try:
+                if applicability_condition_invalid(self.applicability_condition):
+                    return False
+                else:
+                    is_applicable = eval(
+                        self.applicability_condition, {"__builtins__": None}, function_context)
+            except BaseException:
+                return False
 
             return is_applicable
 


### PR DESCRIPTION
- Added "eval" to the blacklist in contains_blacklisted_words
- Updated applicable_to methods of RegistryForm & ConsentSection
    classes with exception handling on eval() usage and conditionals
    to check if the applicability condition is valid before eval