### PR TITLE
rdrf #1874 dummy csp middleware added

### DIFF
--- a/rdrf/rdrf/middleware.py
+++ b/rdrf/rdrf/middleware.py
@@ -1,0 +1,8 @@
+class DummyCSPMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request.csp_nonce = ''
+        response = self.get_response(request)
+        return response

--- a/rdrf/rdrf/settings.py
+++ b/rdrf/rdrf/settings.py
@@ -196,6 +196,8 @@ if SYSTEM_ROLE == SystemRoles.CIC_PROMS:
     MIDDLEWARE = PROMS_MIDDLEWARE
 elif env.get("enable_csp", False):
     MIDDLEWARE.append('csp.middleware.CSPMiddleware')
+else:
+    MIDDLEWARE.append('rdrf.middleware.DummyCSPMiddleware')
 
 INSTALLED_APPS = [
     'django.contrib.contenttypes',


### PR DESCRIPTION
If CSP is not enabled through environment variable - ENABLE_CSP=1
then the dummy csp middleware injects request.csp_nonce with an empty string.